### PR TITLE
Prettify tweets

### DIFF
--- a/src/main/resources/twitter-demo/run_tweetbook_demo.py
+++ b/src/main/resources/twitter-demo/run_tweetbook_demo.py
@@ -23,7 +23,7 @@ from bottle import route, run, template, static_file, request
 
 import sys
 if len(sys.argv)==1:
-    asterix_server = "http://localhost:19002"
+    asterix_server = "http://kiwi.ics.uci.edu:19002"
 else:
     asterix_server = sys.argv[1]
 

--- a/src/main/resources/twitter-demo/run_tweetbook_demo.py
+++ b/src/main/resources/twitter-demo/run_tweetbook_demo.py
@@ -23,7 +23,7 @@ from bottle import route, run, template, static_file, request
 
 import sys
 if len(sys.argv)==1:
-    asterix_server = "http://kiwi.ics.uci.edu:19002"
+    asterix_server = "http://localhost:19002"
 else:
     asterix_server = sys.argv[1]
 

--- a/src/main/resources/twitter-demo/static/js/tweetbook.js
+++ b/src/main/resources/twitter-demo/static/js/tweetbook.js
@@ -150,11 +150,18 @@ $(function () {
     queryWrapper("submit");
   });
 
+  // press enter to submit
   $(document).keypress(function (e) {
     if (e.which == 13) {
       e.preventDefault();
       $("#submit-button").click();
     }
+  });
+
+  // menu-button
+  $("#menu-button").click(function(e) {
+    e.preventDefault();
+    $("#sidebar").toggleClass("toggled");
   });
 });
 
@@ -244,6 +251,8 @@ function setInfoControl(map) {
     this._div.innerHTML = '<h4>Count by ' + logicLevel + '</h4>' + (props ?
       '<b>' + props.NAME + '</b><br />' + 'Count: ' + (props.count ? props.count : 0) : 'Hover over a state');
   };
+
+  info.options = { position: 'topleft' };
 
   info.addTo(map);
 
@@ -652,7 +661,7 @@ function drawMap(mapPlotData) {
     $('.legend').remove();
 
   var legend = L.control({
-    position: 'bottomright'
+    position: 'topleft'
   });
 
   legend.onAdd = function (map) {

--- a/src/main/resources/twitter-demo/static/js/tweetbook.js
+++ b/src/main/resources/twitter-demo/static/js/tweetbook.js
@@ -755,7 +755,7 @@ function drawHashtag(tag_count) {
  **/
 function drawTweets(message) {
   $.each(message, function (i, d) {
-    $('#tweet').append('<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">'+d.tweet+'</p>&mdash;'+d.uname+'</blockquote> <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>');
+    $('#tweet').append('<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">'+d.tweet+'</p>&mdash;'+d.uname+'</blockquote> ');
   });
 }
 

--- a/src/main/resources/twitter-demo/static/js/tweetbook.js
+++ b/src/main/resources/twitter-demo/static/js/tweetbook.js
@@ -755,7 +755,7 @@ function drawHashtag(tag_count) {
  **/
 function drawTweets(message) {
   $.each(message, function (i, d) {
-    $('#tweets tr:last').after('<tr><td>' + d.uname + '<br/>' + d.tweet + '</td></tr>');
+    $('#tweet').append('<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">'+d.tweet+'</p>&mdash;'+d.uname+'</blockquote> <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>');
   });
 }
 

--- a/src/main/resources/twitter-demo/static/js/tweetbook.js
+++ b/src/main/resources/twitter-demo/static/js/tweetbook.js
@@ -463,7 +463,7 @@ function buildTweetSample(type, parameters) {
     aql.push('where $t.create_at >= $ts_start and $t.create_at < $ts_end');
   }
   aql.push('limit 100');
-  aql.push('return {"uname": $t.user.screen_name, "tweet":$t.text_msg};\n')
+  aql.push('return {"uname": $t.user.screen_name, "tweet":$t.text_msg, "id": $t.id, "hashtags": $t.hashtags, "user_mentions": $t.user_mentions};\n')
   return aql.join('\n');
 }
 
@@ -543,7 +543,6 @@ function queryCallbackWrapper(type) {
       reportUserMessage("Oops, no results found for those parameters.", false, "aql");
       return;
     }
-    console.log(res)
     // update map
     if (res.results[0])
       drawMap(res.results[0]);
@@ -763,8 +762,19 @@ function drawHashtag(tag_count) {
  * @ param {object}  tweets query results
  **/
 function drawTweets(message) {
+  console.log(message)
   $.each(message, function (i, d) {
-    $('#tweet').append('<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">'+d.tweet+'</p>&mdash;'+d.uname+'</blockquote> ');
+    var url = "https://api.twitter.com/1/statuses/oembed.json?id=" + d.id;
+    $.ajax({
+      url: url,
+      dataType: "jsonp",
+      success: function (data) {
+        $('#tweet').append(data.html);
+      }
+    });
+    // $('#tweet').append('<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">'+d.tweet+'</p>&mdash;'+d.uname+'</blockquote> ');
+    // $('#tweet').append(" <blockquote class='twitter-tweet' ><a href = 'https://twitter.com/" + d.uname+ "/status/" + d.id + " '></a> </blockquote><script src='http://platform.twitter.com/widgets.js' charset='utf-8'></script>")
+    // $('#tweet').append('<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">These two paired up tonight in what was an amazing evening. Thank you <a href="https://twitter.com/hashtag/NXTConcord?src=hash">#NXTConcord</a> see you soon! <a href="https://twitter.com/wwebalor">@wwebalor</a> <a href="https://twitter.com/ShinsukeN">@ShinsukeN</a> <a href="https://t.co/Y4dIhZ7Js6">https://t.co/Y4dIhZ7Js6</a></p>&mdash; WWE NXT (@WWENXT) <a href="https://twitter.com/WWENXT/status/718266437362663425">April 8, 2016</a></blockquote> <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>')
   });
 }
 

--- a/src/main/resources/twitter-demo/static/js/tweetbook.js
+++ b/src/main/resources/twitter-demo/static/js/tweetbook.js
@@ -790,6 +790,6 @@ function reportUserMessage(message, isPositiveMessage, target) {
  **/
 function clearSidebar() {
   $('#hashcount tr').html('');
-  $('#tweets tr').html('');
+  $('#tweet').html('');
   $('#aql tr').html('');
 }

--- a/src/main/resources/twitter-demo/tweetbook.tpl
+++ b/src/main/resources/twitter-demo/tweetbook.tpl
@@ -29,18 +29,30 @@
             position: absolute;
             top: 0;
             bottom: 0;
-            width: 80%;
-            /*z-index: -1;*/
+            width: 100%;
+            height: 100%;
         }
+
 
         #sidebar {
             position: relative;
             top: 0;
             bottom: 0;
-            left: 80%;
+            left: 100%;
             width: 20%;
             height: 700px;
             overflow: auto;
+            margin-left: -20%;
+            -webkit-transition: all 0.5s ease;
+            -moz-transition: all 0.5s ease;
+            -o-transition: all 0.5s ease;
+            transition: all 0.5s ease;
+            background-color: white;
+            opacity: 0.8;
+        }
+
+        #sidebar.toggled {
+            margin-left: 0;
         }
 
         #time-series {
@@ -55,7 +67,7 @@
             position: absolute;
             left: 20%;
             top: 2%;
-            width: 50%;
+            width: 55%;
         }
 
         #input-group {
@@ -110,6 +122,7 @@
             <input type="text" class="form-control " id="keyword-textbox" placeholder="Key words">
         </div>
         <button type="button" class="btn btn-primary" id="submit-button">Submit</button>
+        <button type="button" class="btn btn-primary" id="menu-button">Menu</button>
     </form>
 </div>
 <div id='time-series'></div>
@@ -145,7 +158,6 @@
             </table>
         </div>
     </div>
-</div>
 </div>
 </body>
 </html>

--- a/src/main/resources/twitter-demo/tweetbook.tpl
+++ b/src/main/resources/twitter-demo/tweetbook.tpl
@@ -18,6 +18,7 @@
     <script src="static/js/dc.min.js"></script>
     <script src="static/js/tweetbook.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
+    <script src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
     <style>
         body {
             margin: 0;

--- a/src/main/resources/twitter-demo/tweetbook.tpl
+++ b/src/main/resources/twitter-demo/tweetbook.tpl
@@ -88,6 +88,16 @@
             margin-right: 8px;
             opacity: 0.7;
         }
+
+        blockquote{
+            padding: 5px 10px;
+            margin: 0 0 10px;
+            font-size: 12px;
+        }
+
+        blockquote p{
+            font-size: 14px;
+        }
     </style>
 </head>
 <body>
@@ -121,15 +131,6 @@
             </table>
         </div>
         <div id="tweet" class="tab-pane">
-            <table class="table" id="tweets">
-                <thead>
-                <tr>
-                    <th>Tweets</th>
-                </tr>
-                </thead>
-                <tbody>
-                </tbody>
-            </table>
         </div>
         <div id="aql" class="tab-pane">
             <table class="table" id="tweets">


### PR DESCRIPTION
Prettify tweets table a lot bit.

The original code (the one you sent me) is out of work because of twitter has change its tweet's url format, using a unique id in the url now. And I found actually it also requires database query.

Since we only has user name and content, I can't find a way using these information to find the corresponding tweet id, so for now just simple text and user name with a bit styling.

Also, I found mapD using its own tweet styling to show tweets, and they seem to have more information like #hashtag or @somebody, so they can highlight them, but we only has plain text, so it's hard to highlight these parts.