### PR TITLE
Using JSONP

### DIFF
--- a/src/main/resources/twitter-demo/run_tweetbook_demo.py
+++ b/src/main/resources/twitter-demo/run_tweetbook_demo.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from urllib2 import URLError, urlopen
+from urllib2 import URLError, urlopen, HTTPError
 from urllib import urlencode
 from json import loads, dumps
 from bottle import route, run, template, static_file, request
@@ -96,5 +96,14 @@ def run_asterix_ddl():
 @route('/update')
 def run_asterix_update():
     return (build_response("update", dict(request.query)))
+
+@route('/query/tweet/<id>')
+def get_tweet(id):
+    url = "https://api.twitter.com/1/statuses/oembed.json?id="+id
+    try:
+        content = urlopen(url).read()
+        return content
+    except HTTPError, e:
+        pass
 
 run(host='0.0.0.0', port=8080, debug=True)

--- a/src/main/resources/twitter-demo/static/js/tweetbook.js
+++ b/src/main/resources/twitter-demo/static/js/tweetbook.js
@@ -454,7 +454,7 @@ function buildTweetSample(type, parameters) {
     aql.push('where $t.create_at >= $ts_start and $t.create_at < $ts_end');
   }
   aql.push('limit 100');
-  aql.push('return {"uname": $t.user.screen_name, "tweet":$t.text_msg};\n')
+  aql.push('return {"uname": $t.user.screen_name, "tweet":$t.text_msg, "id":$t.id};\n')
   return aql.join('\n');
 }
 
@@ -755,7 +755,15 @@ function drawHashtag(tag_count) {
  **/
 function drawTweets(message) {
   $.each(message, function (i, d) {
-    $('#tweets tr:last').after('<tr><td>' + d.uname + '<br/>' + d.tweet + '</td></tr>');
+    // Using JSONP
+    var url = "https://api.twitter.com/1/statuses/oembed.json?id=" + d.id;
+    $.ajax({
+      url: url,
+      dataType: "jsonp",
+      success: function (data) {
+        $('#tweet').append(data.html);
+      }
+    });
   });
 }
 
@@ -790,6 +798,6 @@ function reportUserMessage(message, isPositiveMessage, target) {
  **/
 function clearSidebar() {
   $('#hashcount tr').html('');
-  $('#tweets tr').html('');
+  $('#tweet').html('');
   $('#aql tr').html('');
 }

--- a/src/main/resources/twitter-demo/static/js/tweetbook.js
+++ b/src/main/resources/twitter-demo/static/js/tweetbook.js
@@ -756,12 +756,15 @@ function drawHashtag(tag_count) {
 function drawTweets(message) {
   $.each(message, function (i, d) {
     // Using JSONP
-    var url = "https://api.twitter.com/1/statuses/oembed.json?id=" + d.id;
+    var url = "query/tweet/" + d.id;
     $.ajax({
       url: url,
-      dataType: "jsonp",
+      dataType: "json",
       success: function (data) {
         $('#tweet').append(data.html);
+      },
+      error: function(data) {
+        // do nothing
       }
     });
   });

--- a/src/main/resources/twitter-demo/tweetbook.tpl
+++ b/src/main/resources/twitter-demo/tweetbook.tpl
@@ -122,13 +122,6 @@
         </div>
         <div id="tweet" class="tab-pane">
             <table class="table" id="tweets">
-                <thead>
-                <tr>
-                    <th>Tweets</th>
-                </tr>
-                </thead>
-                <tbody>
-                </tbody>
             </table>
         </div>
         <div id="aql" class="tab-pane">


### PR DESCRIPTION
New branch

Prettify the tweet table done.
There are still some problems:
1. It seems that the normal approach is letting the server sends the request to twitter api not the browser, since using the browser will suffer from the cross domain problem
2. There are 2 approaches to solve the cross domain problem, CORS and JSONP, CORS is more recommended and JSONP is a little old, but it seems that twitter api not support CORS, so I use JSONP.
3. I test in Safari, Chrom and Firefox, some extension may affect the display in Safari, others are all good.
4. Still working on the error handling of JSONP, it's a little tricky, currently it will report 404 if the tweets can not be found( which is normal) in the console