### PR TITLE
Support the Non-ASCII UTF8 keywords

### DIFF
--- a/neo/app/assets/javascripts/searchbar/controllers.js
+++ b/neo/app/assets/javascripts/searchbar/controllers.js
@@ -2,9 +2,9 @@ angular.module('cloudberry.util', ['cloudberry.common'])
   .controller('SearchCtrl', function($scope, $window, Asterix) {
     $scope.search = function() {
       if ($scope.keyword)
-        Asterix.parameters.keyword = $scope.keyword.trim().split(/\s+/);
+        Asterix.parameters.keywords = $scope.keyword.trim().split(/\s+/);
       else
-        Asterix.parameters.keyword = [];
+        Asterix.parameters.keywords = [];
       Asterix.queryType = 'search';
       Asterix.query(Asterix.parameters, Asterix.queryType);
     };

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterViewsManagerActor.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterViewsManagerActor.scala
@@ -1,5 +1,7 @@
 package edu.uci.ics.cloudberry.zion.asterix
 
+import java.security.MessageDigest
+
 import akka.actor.{Actor, ActorRef, Props}
 import edu.uci.ics.cloudberry.zion.actor.{ViewMetaRecord, ViewsManagerActor}
 import edu.uci.ics.cloudberry.zion.common.Config
@@ -18,7 +20,7 @@ class TwitterViewsManagerActor(val conn: AsterixConnection, override val sourceA
 
   override def getViewKey(query: DBQuery): String = {
     val keyword = query.predicates.find(_.isInstanceOf[KeywordPredicate]).map(_.asInstanceOf[KeywordPredicate].keywords.head).getOrElse("")
-    sourceName + "_" + keyword
+    sourceName + "_" + MessageDigest.getInstance("MD5").digest(keyword.getBytes("UTF-8")).map("%02x" format _).mkString
   }
 
   override def flushInterval: FiniteDuration = config.ViewMetaFlushInterval
@@ -41,14 +43,14 @@ class TwitterViewsManagerActor(val conn: AsterixConnection, override val sourceA
     val optKeyword = query.predicates.find(_.isInstanceOf[KeywordPredicate]).map(_.asInstanceOf[KeywordPredicate])
     if (optKeyword.isDefined) {
       val keyword = optKeyword.get.keywords.head
-      conn.post(generateSubSetViewAQL(sourceName, keyword)).map { ws =>
+      conn.post(generateSubSetViewAQL(sourceName, key, keyword)).map { ws =>
         if (ws.status != 200) throw UpdateFailedDBException(ws.body)
         ViewMetaRecord(sourceName, key, SummaryLevel(SpatialLevels.Point, TimeLevels.TimeStamp),
                        startTime = new DateTime(0l), lastVisitTime = new DateTime(), lastUpdateTime = new DateTime(),
                        visitTimes = 0, updateCycle = flushInterval)
       }
     } else {
-      conn.post(generateSummaryViewAQL(sourceName, query.summaryLevel)).map { ws =>
+      conn.post(generateSummaryViewAQL(sourceName, key, query.summaryLevel)).map { ws =>
         if (ws.status != 200) throw UpdateFailedDBException(ws.body)
         ViewMetaRecord(sourceName, key, SummaryLevel(SpatialLevels.County, TimeLevels.Day),
                        startTime = new DateTime(0l), lastVisitTime = new DateTime(), lastUpdateTime = new DateTime(),
@@ -112,9 +114,8 @@ object TwitterViewsManagerActor {
     new DBQuery(summaryLevel, Seq.empty)
   }
 
-  def generateSubSetViewAQL(sourceName: String, keyword: String): String = {
+  def generateSubSetViewAQL(sourceName: String, viewName: String, keyword: String): String = {
     import TwitterDataStoreActor._
-    val viewName = s"${sourceName}_${keyword}"
     s"""
        |use dataverse $DataVerse
        |drop dataset $viewName if exists
@@ -139,8 +140,7 @@ object TwitterViewsManagerActor {
        |)""".stripMargin
   }
 
-  def generateSummaryViewAQL(sourceName: String, summaryLevel: SummaryLevel): String = {
-    val viewName = s"${sourceName}_"
+  def generateSummaryViewAQL(sourceName: String, viewName: String, summaryLevel: SummaryLevel): String = {
     import TwitterCountyDaySummaryView._
 
     s"""

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterViewsManagerActorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterViewsManagerActorTest.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class TwitterViewsManagerActorTest extends Specification with Mockito with TestData{
+class TwitterViewsManagerActorTest extends Specification with Mockito with TestData {
 
   val mockConn = mock[AsterixConnection]
   when(mockConn.post(any[String])).thenAnswer(new Answer[Future[String]] {
@@ -93,7 +93,7 @@ class TwitterViewsManagerActorTest extends Specification with Mockito with TestD
     }
 
     "generateSummaryViewAQL" in {
-      val str = TwitterViewsManagerActor.generateSummaryViewAQL("ds_tweet", TwitterCountyDaySummaryView.SummaryLevel)
+      val str = TwitterViewsManagerActor.generateSummaryViewAQL("ds_tweet", "ds_tweet_", TwitterCountyDaySummaryView.SummaryLevel)
       str.trim must_== ("""
                           |use dataverse twitter
                           |drop dataset ds_tweet_ if exists
@@ -140,7 +140,7 @@ class TwitterViewsManagerActorTest extends Specification with Mockito with TestD
     }
 
     "generateSubSetViewAQL" in {
-      val aql = TwitterViewsManagerActor.generateSubSetViewAQL("ds_tweet", "rain")
+      val aql = TwitterViewsManagerActor.generateSubSetViewAQL("ds_tweet", "ds_tweet_rain", "rain")
       aql.trim must_== ("""
                           |use dataverse twitter
                           |drop dataset ds_tweet_rain if exists


### PR DESCRIPTION
This PR 

- Support the Non-ASCII UTF8 keywords. 
- Fix the front-end query value, so it will send the multi-keywords to the back-end.

Solving issue #81 

@MoniMoledo @aishwaryakapse 
As a training process, I will make some small PR for you two to review. Ask as many questions as you can 😄 