### PR TITLE
Split a large AQL request to atomic part

### DIFF
--- a/neo/app/controllers/Application.scala
+++ b/neo/app/controllers/Application.scala
@@ -30,7 +30,7 @@ class Application @Inject()(val wsClient: WSClient,
                            ) extends Controller {
 
   val config = new Config(configuration)
-  val asterixConn = new AsterixConnection(wsClient, config.AsterixURL)
+  val asterixConn = new AsterixConnection(config.AsterixURL, wsClient, config)
 
   Logger.logger.info("I'm initializing")
   val checkViewStatus = Migration_20160324(asterixConn).up()

--- a/neo/app/controllers/Application.scala
+++ b/neo/app/controllers/Application.scala
@@ -37,7 +37,7 @@ class Application @Inject()(val wsClient: WSClient,
   val USGeoGnosis = Knowledge.buildUSKnowledge(environment)
 
   Await.ready(checkViewStatus, config.AwaitInitial) onComplete {
-    case Success(response: WSResponse) => Logger.logger.info(response.body)
+    case Success(succeed: Boolean) => if (!succeed) throw new IllegalStateException("Initialization failed")
     case Failure(ex) => Logger.logger.error(ex.getMessage); throw ex
   }
 

--- a/neo/app/db/Migration_20160324.scala
+++ b/neo/app/db/Migration_20160324.scala
@@ -10,14 +10,14 @@ private[db] class Migration_20160324(val connection: AsterixConnection) {
 
   import Migration_20160324._
 
-  def up(): Future[WSResponse] = {
+  def up(): Future[Boolean] = {
     Logger.logger.info("Migration create table")
-    post(createDataverse + createEventDataTable)
+    connection.postUpdate(createDataverse + createEventDataTable)
   }
 
-  def down(): Future[WSResponse] = {
+  def down(): Future[Boolean] = {
     Logger.logger.info("Migration destroy table")
-    post(dropEventTable + dropDataverse)
+    connection.postUpdate(dropEventTable + dropDataverse)
   }
 
   private[db] def createDataverse(): String = {
@@ -119,7 +119,6 @@ private[db] class Migration_20160324(val connection: AsterixConnection) {
     """.stripMargin
   }
 
-  private def post(statement: String): Future[WSResponse] = connection.post(statement)
 }
 
 object Migration_20160324 {

--- a/neo/conf/application.conf
+++ b/neo/conf/application.conf
@@ -87,6 +87,10 @@ view.update.interval = "30 minutes"
 
 view.meta.flush.interval = "30 minutes"
 
+asterix.conn.timeout.query = "15 seconds"
+
+asterix.conn.timeout.update = "Duration.Inf"
+
 asterixdb.url = "http://kiwi.ics.uci.edu:19002/aql"
 asterixdb.view.meta.name = "viewMeta"
 tweet.url = "http://twitter-search-proxy.herokuapp.com/search/tweets?q=%s"

--- a/neo/conf/application.conf
+++ b/neo/conf/application.conf
@@ -89,7 +89,7 @@ view.meta.flush.interval = "30 minutes"
 
 asterix.conn.timeout.query = "15 seconds"
 
-asterix.conn.timeout.update = "Duration.Inf"
+asterix.conn.timeout.update = "24 hours"
 
 asterixdb.url = "http://kiwi.ics.uci.edu:19002/aql"
 asterixdb.view.meta.name = "viewMeta"

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/AQLStatement.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/AQLStatement.scala
@@ -22,14 +22,7 @@ class AsterixConnection(url: String, wSClient: WSClient, config: Config)(implici
 
   import AsterixConnection._
 
-  def post(aql: String): Future[WSResponse] = {
-    log.info("AQL:" + aql)
-    val f = wSClient.url(url).withRequestTimeout(Duration.Inf).post(aql)
-    f.onFailure(wsFailureHandler(aql))
-    f
-  }
-
-  def postQuery(aql: String, responseWhenFail: JsValue = defaultEmptyResponse): Future[JsValue] = {
+ def postQuery(aql: String, responseWhenFail: JsValue = defaultEmptyResponse): Future[JsValue] = {
     postWithCheckingStatus(aql, (ws: WSResponse) => ws.json, (ws: WSResponse) => responseWhenFail)
   }
 
@@ -46,6 +39,13 @@ class AsterixConnection(url: String, wSClient: WSClient, config: Config)(implici
         failureHandler(wsResponse)
       }
     }
+  }
+
+  protected def post(aql: String): Future[WSResponse] = {
+    log.info("AQL:" + aql)
+    val f = wSClient.url(url).withRequestTimeout(Duration.Inf).post(aql)
+    f.onFailure(wsFailureHandler(aql))
+    f
   }
 
   protected def wsFailureHandler(aql: String): PartialFunction[Throwable, Unit] = {

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/AQLStatement.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/AQLStatement.scala
@@ -1,10 +1,13 @@
 package edu.uci.ics.cloudberry.zion.asterix
 
 import edu.uci.ics.cloudberry.util.Logging
+import edu.uci.ics.cloudberry.zion.common.Config
+import play.api.libs.json.{JsArray, JsValue}
 import play.api.libs.ws.{WSClient, WSResponse}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.parsing.json.JSONObject
 
 class AQLStatement() {
 
@@ -15,16 +18,41 @@ object AQLStatement {
 }
 
 
-class AsterixConnection(wSClient: WSClient, url: String)(implicit ec: ExecutionContext) extends Logging {
+class AsterixConnection(url: String, wSClient: WSClient, config: Config)(implicit ec: ExecutionContext) extends Logging {
+
+  import AsterixConnection._
 
   def post(aql: String): Future[WSResponse] = {
     log.info("AQL:" + aql)
     val f = wSClient.url(url).withRequestTimeout(Duration.Inf).post(aql)
-    f.onFailure(failureHandler(aql))
+    f.onFailure(wsFailureHandler(aql))
     f
   }
 
-  protected def failureHandler(aql: String): PartialFunction[Throwable, Unit] = {
+  def postQuery(aql: String, responseWhenFail: JsValue = defaultEmptyResponse): Future[JsValue] = {
+    postWithCheckingStatus(aql, (ws: WSResponse) => ws.json, (ws: WSResponse) => responseWhenFail)
+  }
+
+  def postUpdate(aql: String): Future[Boolean] = {
+    postWithCheckingStatus(aql, (ws: WSResponse) => true, (ws: WSResponse) => false)
+  }
+
+  protected def postWithCheckingStatus[T](aql: String, succeedHandler: WSResponse => T, failureHandler: WSResponse => T): Future[T] = {
+    post(aql).map { wsResponse =>
+      if (wsResponse.status == 200) {
+        succeedHandler(wsResponse)
+      } else {
+        log.error("AQL failed:" + wsResponse.body)
+        failureHandler(wsResponse)
+      }
+    }
+  }
+
+  protected def wsFailureHandler(aql: String): PartialFunction[Throwable, Unit] = {
     case e: Throwable => log.error("WS Error:" + aql, e); throw e
   }
+}
+
+object AsterixConnection {
+  val defaultEmptyResponse = JsArray(Seq.empty[JsValue])
 }

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/AQLStatement.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/AQLStatement.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.cloudberry.zion.asterix
 
 import edu.uci.ics.cloudberry.util.Logging
 import edu.uci.ics.cloudberry.zion.common.Config
-import play.api.libs.json.{JsArray, JsValue}
+import play.api.libs.json.{JsArray, JsValue, Json}
 import play.api.libs.ws.{WSClient, WSResponse}
 
 import scala.concurrent.duration.Duration
@@ -35,7 +35,7 @@ class AsterixConnection(url: String, wSClient: WSClient, config: Config)(implici
       if (wsResponse.status == 200) {
         succeedHandler(wsResponse)
       } else {
-        log.error("AQL failed:" + wsResponse.body)
+        log.error("AQL failed:" + Json.prettyPrint(wsResponse.json))
         failureHandler(wsResponse)
       }
     }
@@ -54,5 +54,5 @@ class AsterixConnection(url: String, wSClient: WSClient, config: Config)(implici
 }
 
 object AsterixConnection {
-  val defaultEmptyResponse = JsArray(Seq.empty[JsValue])
+  val defaultEmptyResponse = Json.toJson(Seq(Seq.empty[JsValue]))
 }

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/AsterixDataStore.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/AsterixDataStore.scala
@@ -2,6 +2,7 @@ package edu.uci.ics.cloudberry.zion.asterix
 
 import edu.uci.ics.cloudberry.zion.actor.DataStoreActor
 import edu.uci.ics.cloudberry.zion.model.{DBQuery, DBSyncQuery, Response}
+import play.api.libs.json.JsValue
 import play.api.libs.ws.WSResponse
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -13,9 +14,9 @@ abstract class AsterixDataStoreActor(override val name: String, val aqlConn: Ast
   override def query(query: DBQuery): Future[Response] = {
     val aqlVisitor = new AQLVisitor(name)
     query.accept(aqlVisitor)
-    val wsResponse = aqlConn.post(aqlVisitor.aqlBuilder.toString())
-    wsResponse.map(handleWSResponse(_))
+    val fJSResult = aqlConn.postQuery(aqlVisitor.aqlBuilder.toString())
+    fJSResult.map(handleJSResult(_))
   }
 
-  def handleWSResponse(wsResponse: WSResponse): Response
+  def handleJSResult(jsValue: JsValue): Response
 }

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterCountyDaySummaryView.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterCountyDaySummaryView.scala
@@ -34,9 +34,9 @@ class TwitterCountyDaySummaryView(val conn: AsterixConnection,
 
   override def updateView(from: DateTime, to: DateTime): Future[Unit] = {
     val aql = TwitterViewsManagerActor.generateSummaryUpdateAQL(sourceName, key, summaryLevel, from, to)
-    conn.post(aql).map[Unit] { response: WSResponse =>
-      if (response.status != 200) {
-        throw UpdateFailedDBException(response.body)
+    conn.postUpdate(aql).map[Unit] { succeed : Boolean =>
+      if (!succeed) {
+        throw UpdateFailedDBException(key)
       }
     }
   }

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterCountyDaySummaryView.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterCountyDaySummaryView.scala
@@ -42,7 +42,7 @@ class TwitterCountyDaySummaryView(val conn: AsterixConnection,
   }
 
   override def askViewOnly(query: DBQuery): Future[Response] = {
-    conn.post(generateAQL(query)).map(TwitterDataStoreActor.handleAllInOneWSResponse)
+    askAsterixAndGetAllResponse(conn, query)
   }
 
   override def updateInterval: FiniteDuration = config.ViewUpdateInterval
@@ -94,39 +94,60 @@ object TwitterCountyDaySummaryView {
 
   }
 
-  def generateAQL(query: DBQuery): String = {
+  def askAsterixAndGetAllResponse(conn: AsterixConnection, query: DBQuery)(implicit ec: ExecutionContext): Future[Response] = {
+    import TwitterDataStoreActor.handleKeyCountResponse
+    val fMap = conn.postQuery(generateByMapAQL(query)).map(handleKeyCountResponse)
+    val fTime = conn.postQuery(generateByTimeAQL(query)).map(handleKeyCountResponse)
+    val fHashtag = conn.postQuery(generateByHashtagAQL(query)).map(handleKeyCountResponse)
+    for {
+      mapResult <- fMap
+      timeResult <- fTime
+      hashtagResult <- fHashtag
+    } yield SpatialTimeCount(mapResult, timeResult, hashtagResult)
+  }
 
+  def generateByMapAQL(query: DBQuery): String = {
+    val common = applyPredicate(query)
+    s"""|$common
+        |let $$map := (
+        |for $$t in $$common
+        |${byMap(query.summaryLevel.spatialLevel)}
+        |)
+        |return $$map;
+        |""".stripMargin
+  }
+
+  def generateByTimeAQL(query: DBQuery): String = {
+    val common = applyPredicate(query)
+    s"""|$common
+        |let $$time := (
+        |for $$t in $$common
+        |${byTime(query.summaryLevel.timeLevel)}
+        |)
+        |return $$time
+        |""".stripMargin
+  }
+
+  def generateByHashtagAQL(query: DBQuery): String = {
+    val common = applyPredicate(query)
+    s"""|$common
+        |let $$hashtag := (
+        |for $$t in $$common
+        |${byHashTag()}
+        |)
+        |return $$hashtag
+        |""".stripMargin
+  }
+
+  private def applyPredicate(query: DBQuery): String = {
     val predicate = query.predicates.map(visitPredicate("t", query.summaryLevel, _)).mkString("\n")
-    val common =
-      s"""
-         |use dataverse $DataVerse
-         |let $$common := (
-         |for $$t in dataset $DataSet
-         |$predicate
-         |return $$t
-         |)
-         |""".stripMargin
     s"""
-       |$common
-       |let $$map := (
-       |for $$t in $$common
-       |${byMap(query.summaryLevel.spatialLevel)}
+       |use dataverse $DataVerse
+       |let $$common := (
+       |for $$t in dataset $DataSet
+       |$predicate
+       |return $$t
        |)
-       |return $$map;
-       |
-       |$common
-       |let $$time := (
-       |for $$t in $$common
-       |${byTime(query.summaryLevel.timeLevel)}
-       |)
-       |return $$time
-       |
-       |$common
-       |let $$hashtag := (
-       |for $$t in $$common
-       |${byHashTag()}
-       |)
-       |return $$hashtag
        |""".stripMargin
   }
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterDataStoreActor.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterDataStoreActor.scala
@@ -3,9 +3,7 @@ package edu.uci.ics.cloudberry.zion.asterix
 import edu.uci.ics.cloudberry.zion.actor.DataStoreActor
 import edu.uci.ics.cloudberry.zion.common.Config
 import edu.uci.ics.cloudberry.zion.model._
-import org.joda.time.DateTime
-import play.api.Logger
-import play.api.libs.json.{JsArray, Json}
+import play.api.libs.json.{JsArray, JsValue}
 import play.api.libs.ws.WSResponse
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -21,7 +19,7 @@ class TwitterDataStoreActor(conn: AsterixConnection, config: Config)(implicit ec
       case q: SampleQuery =>
         conn.post(generateSampleAQL(name, q)).map(handleSampleResponse)
       case q: DBQuery =>
-        conn.post(generateAQL(name, q)).map(handleAllInOneWSResponse)
+        askAsterixAndGetAllResponse(conn, name, q)
     }
   }
 }
@@ -57,57 +55,58 @@ object TwitterDataStoreActor {
     )
   }
 
-  def handleAllInOneWSResponse(response: WSResponse): Response = {
-    //TODO different aggregation cost differently, it may be better to split the query, which makes the coding easier.
-    val seq = Json.parse(response.body.replaceAll(" \\]\n\\[", " ,\n")).as[Seq[Seq[KeyCountPair]]]
-    SpatialTimeCount(seq(0), seq(1), seq(2))
-  }
-
   def handleSampleResponse(wSResponse: WSResponse): Response = {
     SampleList(wSResponse.json.as[Seq[SampleTweet]])
   }
 
-  def handleKeyCountResponse(jsArray: JsArray): Seq[KeyCountPair] = {
-    jsArray.apply(0).as[Seq[KeyCountPair]]
+  def handleKeyCountResponse(jsValue: JsValue): Seq[KeyCountPair] = {
+    jsValue.asInstanceOf[JsArray].apply(0).as[Seq[KeyCountPair]]
   }
 
-  def generateAQL(name: String, query: DBQuery): String = {
-    val aqlVisitor = AQLVisitor(name)
-    val predicate = query.predicates.map(p => aqlVisitor.visitPredicate("t", p)).mkString("\n")
-    val common =
-      s"""
-         |use dataverse $DataVerse
-         |let $$common := (
-         |for $$t in dataset $name
-         |$predicate
-         |return $$t
-         |)
-         |""".stripMargin
+  def askAsterixAndGetAllResponse(conn: AsterixConnection, name: String, query: DBQuery)
+                                 (implicit ec: ExecutionContext): Future[Response] = {
+    val fMap = conn.postQuery(generateByMapAQL(name, query)).map(handleKeyCountResponse)
+    val fTime = conn.postQuery(generateByTimeAQL(name, query)).map(handleKeyCountResponse)
+    val fHashtag = conn.postQuery(generateByHashtagAQL(name, query)).map(handleKeyCountResponse)
+    for {
+      mapResult <- fMap
+      timeResult <- fTime
+      hashtagResult <- fHashtag
+    } yield SpatialTimeCount(mapResult, timeResult, hashtagResult)
+  }
 
-    s"""
-       |
-       |$common
-       |let $$map := (
-       |for $$t in $$common
-       |${byMap(query.summaryLevel.spatialLevel)}
-       |)
-       |return $$map
-       |
-       |$common
-       |let $$time := (
-       |for $$t in $$common
-       |${byTime(query.summaryLevel.timeLevel)}
-       |)
-       |return $$time
-       |
-       |$common
-       |let $$hashtag := (
-       |for $$t in $$common
-       |where not(is-null($$t.hashtags))
-       |${byHashTag()}
-       |)
-       |return $$hashtag
-       |
+  def generateByMapAQL(datasetName: String, query: DBQuery): String = {
+    val common = applyPredicate(datasetName, query)
+    s"""|$common
+        |let $$map := (
+        |for $$t in $$common
+        |${byMap(query.summaryLevel.spatialLevel)}
+        |)
+        |return $$map
+        |""".stripMargin
+  }
+
+  def generateByTimeAQL(datasetName: String, query: DBQuery): String = {
+    val common = applyPredicate(datasetName, query)
+    s"""|$common
+        |let $$time := (
+        |for $$t in $$common
+        |${byTime(query.summaryLevel.timeLevel)}
+        |)
+        |return $$time
+        |""".stripMargin
+  }
+
+  def generateByHashtagAQL(datasetName: String, query: DBQuery): String = {
+    val common = applyPredicate(datasetName, query)
+    s"""|common
+        |let $$hashtag := (
+        |for $$t in $$common
+        |where not(is-null($$t.hashtags))
+        |${byHashTag()}
+        |)
+        |return $$hashtag
+        |
        |""".stripMargin
   }
 
@@ -124,6 +123,19 @@ object TwitterDataStoreActor {
   }
 
   //TODO move this hacking code to visitor
+  private def applyPredicate(datasetName: String, query: DBQuery): String = {
+    val aqlVisitor = AQLVisitor(datasetName)
+    val predicate = query.predicates.map(p => aqlVisitor.visitPredicate("t", p)).mkString("\n")
+    s"""
+       |use dataverse $DataVerse
+       |let $$common := (
+       |for $$t in dataset $datasetName
+       |$predicate
+       |return $$t
+       |)
+       |""".stripMargin
+  }
+
   private def byMap(level: SpatialLevels.Value): String = {
     s"""
        |group by $$c := $$t.${SpatialLevelMap.getOrElse(level, FieldStateID)} with $$t

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterKeywordViewActor.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterKeywordViewActor.scala
@@ -61,7 +61,7 @@ class TwitterKeywordViewActor(val conn: AsterixConnection,
       case q: SampleQuery =>
         conn.post(generateSampleAQL(key, q.copy(predicates = newPred))).map(handleSampleResponse)
       case q: DBQuery =>
-        conn.post(generateAQL(key, new DBQuery(q.summaryLevel, newPred))).map(handleAllInOneWSResponse)
+        askAsterixAndGetAllResponse(conn, key,new DBQuery(q.summaryLevel, newPred))
     }
   }
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterKeywordViewActor.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterKeywordViewActor.scala
@@ -40,9 +40,9 @@ class TwitterKeywordViewActor(val conn: AsterixConnection,
 
   override def updateView(from: DateTime, to: DateTime): Future[Unit] = {
     val aql = TwitterViewsManagerActor.generateKeywordUpdateAQL(sourceName, key, keyword, from, to)
-    conn.post(aql).map[Unit] { response: WSResponse =>
-      if (response.status != 200) {
-        throw UpdateFailedDBException(response.body)
+    conn.postUpdate(aql).map[Unit] { succeed: Boolean =>
+      if (!succeed) {
+        throw UpdateFailedDBException(key + ", keyword is:" + keyword)
       }
     }
   }
@@ -50,7 +50,7 @@ class TwitterKeywordViewActor(val conn: AsterixConnection,
   override def askViewOnly(query: DBQuery): Future[Response] = {
     val originKeywordP = query.predicates.find(_.isInstanceOf[KeywordPredicate]).map(_.asInstanceOf[KeywordPredicate]).get
     val keywords = originKeywordP.keywords.filterNot(_ == keyword)
-    val newPred=
+    val newPred =
       if (keywords.length == 0) {
         query.predicates.filterNot(_.isInstanceOf[KeywordPredicate])
       } else {
@@ -59,9 +59,9 @@ class TwitterKeywordViewActor(val conn: AsterixConnection,
 
     query match {
       case q: SampleQuery =>
-        conn.post(generateSampleAQL(key, q.copy(predicates = newPred))).map(handleSampleResponse)
+        conn.postQuery(generateSampleAQL(key, q.copy(predicates = newPred))).map(handleSampleResponse)
       case q: DBQuery =>
-        askAsterixAndGetAllResponse(conn, key,new DBQuery(q.summaryLevel, newPred))
+        askAsterixAndGetAllResponse(conn, key, new DBQuery(q.summaryLevel, newPred))
     }
   }
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/common/Config.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/common/Config.scala
@@ -5,6 +5,7 @@ import play.api.Configuration
 import scala.concurrent.duration._
 
 class Config(config: Configuration) {
+
   import Config._
 
   val AsterixURL = config.getString("asterixdb.url").getOrElse("testing")
@@ -20,9 +21,13 @@ class Config(config: Configuration) {
   val ViewUpdateInterval = config.getString("view.update.interval").map(parseTimePair).getOrElse(30 minutes)
 
   val ViewMetaFlushInterval = config.getString("view.meta.flush.interval").map(parseTimePair).getOrElse(30 minutes)
+
+  val AQLQueryConnTimeOut = config.getString("asterix.conn.timeout.query").map(parseTimePair).getOrElse(10 seconds)
+
+  val AQLUpdateConnTimeOut = config.getString("asterix.conn.timeout.update").map(parseTimePair).getOrElse(Duration.Inf)
 }
 
-object Config{
+object Config {
   def parseTimePair(timeString: String) = {
     val split = timeString.split("\\s+")
     FiniteDuration(split(0).toLong, split(1))

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/experimental/DataStoreActor.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/experimental/DataStoreActor.scala
@@ -14,7 +14,7 @@ class DataStoreActor(val name: String, val schema: Schema, val conn: AsterixConn
   import DataStoreActor._
 
   override def receive: Receive = {
-    case query: Query => val thisSender = sender(); conn.post(parseQuery(name, schema, query)).map(thisSender ! _.json)
+    case query: Query => val thisSender = sender(); conn.postQuery(parseQuery(name, schema, query)).map(thisSender ! _)
   }
 
 }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/TestUtil.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/TestUtil.scala
@@ -18,12 +18,11 @@ import org.specs2.mock.Mockito
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Action
 
-object TestUtil {
-  /**
-    * @param block
-    * @tparam T
-    * @return
-    */
+object TestUtil extends Mockito {
+  val mockPlayConfig = mock[Configuration]
+  mockPlayConfig.getString(anyString, any) returns None
+  val cloudberryConfig = new Config(mockPlayConfig)
+
   def withAsterixConn[T](expectedResponse: JsValue)(block: AsterixConnection => T)(implicit ec: ExecutionContext): T = {
     Server.withRouter() {
       //* this mock server can't write the request, we can not let the result based on the request
@@ -33,7 +32,7 @@ object TestUtil {
     } { implicit port =>
       implicit val materializer = Play.current.materializer
       WsTestClient.withClient { client =>
-        block(new AsterixConnection(client, "/aql"))
+        block(new AsterixConnection("/aql", client, cloudberryConfig))
       }
     }
   }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/TestUtil.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/TestUtil.scala
@@ -116,7 +116,7 @@ trait MockConnClient extends Mockito {
       override def answer(invocation: InvocationOnMock): Future[JsValue] = {
         val aql = invocation.getArguments.head.asInstanceOf[String].trim
         Future(aql2jsonAnswer.getOrElse(aql, {
-          println(aql);
+          System.err.println(aql)
           throw new IllegalArgumentException(aql)
         }))
       }
@@ -142,8 +142,7 @@ trait MockConnClient extends Mockito {
         if (iter.hasNext) {
           Future(iter.next())
         } else {
-          println(aql)
-          Future(null)
+          throw new IllegalArgumentException(aql)
         }
       }
     })
@@ -158,7 +157,7 @@ trait MockConnClient extends Mockito {
         if (aqlSet.apply(aql.trim)) {
           Future(true)
         } else {
-          println(aql)
+          System.err.println(aql)
           Future(false)
         }
       }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/UtilTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/UtilTest.scala
@@ -3,6 +3,8 @@ package edu.uci.ics.cloudberry.zion.actor
 import edu.uci.ics.cloudberry.zion.asterix.TestData
 import org.specs2.mock.Mockito
 import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 import org.specs2.mutable.Specification
 
 import scala.concurrent.{Await, Future}

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/UtilTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/UtilTest.scala
@@ -1,12 +1,14 @@
 package edu.uci.ics.cloudberry.zion.actor
 
 import edu.uci.ics.cloudberry.zion.asterix.TestData
+import org.specs2.mock.Mockito
+import org.mockito.Mockito._
 import org.specs2.mutable.Specification
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
-class UtilTest extends Specification with TestData {
+class UtilTest extends Specification with TestData with Mockito {
 
   "A future" should {
     "be registered to multiple callback functions if using map" in {
@@ -20,8 +22,23 @@ class UtilTest extends Specification with TestData {
         v
       }
 
-      Await.result(fMapped, 300 millisecond) must_== 200
-      v1 must_==(500)
+      Await.result(fMapped, 400 millisecond) must_== 200
+      v1 must_== (500)
+    }
+  }
+
+  "A mock" should {
+    "throws something wrong if given unregistered value" in {
+      class Foo() {
+        def foo(arg: String): String = ???
+      }
+      val mockFoo = mock[Foo]
+      when(mockFoo.foo("foo")).thenReturn("foo").thenReturn("foo2")
+      println(mockFoo.foo("unknown"))
+      mockFoo.foo("foo") must_== "foo"
+      mockFoo.foo("unknown") must_!= "foo"
+      mockFoo.foo("foo") must_== "foo2"
+      mockFoo.foo("foo") must_== "foo2"
     }
   }
 }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TestData.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TestData.scala
@@ -42,14 +42,16 @@ trait TestData {
   val dayResult = Seq[KeyCountPair](KeyCountPair("2012-01-01", 1), KeyCountPair("2012-01-02", 2))
   val hashTagResult = Seq[KeyCountPair](KeyCountPair("youShallPass", 100))
   val byStateByDayResult = SpatialTimeCount(stateResult, dayResult, hashTagResult)
-  val byStateByDayResponse = JsArray(Seq(stateResult, dayResult, hashTagResult).map(Json.toJson(_)))
+  val byStateByDayResponse = Seq(Seq(stateResult), Seq(dayResult), Seq(hashTagResult)).map(Json.toJson(_))
 
   // Create by county, by month request
   val CountyMonthSummary = SummaryLevel(SpatialLevels.County, TimeLevels.Month)
   val byCountyMonthQuery = new DBQuery(CountyMonthSummary, Seq(timePredicate1, idPredicate))
   val monthResult = Seq[KeyCountPair](KeyCountPair("2012-01", 1), KeyCountPair("2012--02", 2))
   val byCountyMonthResult = SpatialTimeCount(stateResult, monthResult, hashTagResult)
-  val byCountyMonthResponse = JsArray(Seq(stateResult, monthResult, hashTagResult).map(Json.toJson(_)))
+  val byCountyMonthResponse = Seq(Seq(stateResult), Seq(monthResult), Seq(hashTagResult)).map(Json.toJson(_))
+
+  val emptyKeyCountResponse = Json.toJson(Seq(Seq.empty[KeyCountPair]))
 
   // Create a partially intersected time range db query
   val partialTime = TimePredicate(FieldCreateAt, Seq(new Interval(startTime1, new DateTime())))

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TestData.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TestData.scala
@@ -143,14 +143,190 @@ trait TestData {
   val byCountyMonthQuery = new DBQuery(CountyMonthSummary, Seq(timePredicate1, idPredicate))
   val monthResult = Seq[KeyCountPair](KeyCountPair("2012-01", 1), KeyCountPair("2012--02", 2))
   val byCountyMonthResult = SpatialTimeCount(stateResult, monthResult, hashTagResult)
-  val byCountyMonthAQLMap = Seq("map" -> Seq(stateResult), "day" -> Seq(monthResult), "hash" -> Seq(hashTagResult))
-    .toMap.mapValues(Json.toJson(_))
+  val byCountyMonthMapAQL =
+    s"""
+       |use dataverse twitter
+       |let $$common := (
+       |for $$t in dataset ds_tweet_
+       |
+       |where
+       |
+       |(get-interval-start($$t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+       |and get-interval-start($$t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
+       |
+       |
+       |
+       |let $$set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+       |for $$sid in $$set
+       |where $$t.countyID = $$sid
+       |
+       |return $$t
+       |)
+       |
+       |let $$map := (
+       |for $$t in $$common
+       |
+       |group by $$c := $$t.countyID with $$t
+       |return { "key": string($$c) , "count": sum(for $$x in $$t return $$x.tweetCount) }
+       |
+       |)
+       |return $$map;
+       |""".stripMargin.trim
+  val byCountyMonthTimeAQL =
+    s"""
+       |use dataverse twitter
+       |let $$common := (
+       |for $$t in dataset ds_tweet_
+       |
+       |where
+       |
+       |(get-interval-start($$t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+       |and get-interval-start($$t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
+       |
+       |
+       |
+       |let $$set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+       |for $$sid in $$set
+       |where $$t.countyID = $$sid
+       |
+       |return $$t
+       |)
+       |
+       |let $$time := (
+       |for $$t in $$common
+       |
+       |group by $$c := print-datetime(get-interval-start($$t.timeBin), "YYYY-MM") with $$t
+       |return { "key" : $$c, "count": sum(for $$x in $$t return $$x.tweetCount)}
+       |
+       |)
+       |return $$time
+     """.stripMargin.trim
+  val byCountyMonthHashtagAQL =
+    s"""
+       |use dataverse twitter
+       |let $$common := (
+       |for $$t in dataset ds_tweet_
+       |
+       |where
+       |
+       |(get-interval-start($$t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+       |and get-interval-start($$t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
+       |
+       |
+       |
+       |let $$set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+       |for $$sid in $$set
+       |where $$t.countyID = $$sid
+       |
+       |return $$t
+       |)
+       |
+       |let $$hashtag := (
+       |for $$t in $$common
+       |
+       |for $$h in $$t.topHashTags
+       |group by $$tag := $$h.tag with $$h
+       |let $$c := sum(for $$x in $$h return $$x.count)
+       |order by $$c desc
+       |limit 50
+       |return { "key": $$tag, "count" : $$c}
+       |
+       |)
+       |return $$hashtag
+     """.stripMargin.trim
+
+  val byCountyMonthAQLMap = Seq(byCountyMonthMapAQL -> Seq(stateResult),
+                                byCountyMonthTimeAQL -> Seq(monthResult),
+                                byCountyMonthHashtagAQL -> Seq(hashTagResult)).toMap.mapValues(Json.toJson(_))
 
   val emptyKeyCountResponse = Json.toJson(Seq(Seq.empty[KeyCountPair]))
 
   // Create a partially intersected time range db query
-  val partialTime = TimePredicate(FieldCreateAt, Seq(new Interval(startTime1, new DateTime())))
+  val nowTime = new DateTime()
+  val formatNow = AQLVisitor.TimeFormat.print(nowTime)
+  val partialTime = TimePredicate(FieldCreateAt, Seq(new Interval(startTime1, nowTime)))
   val partialQuery = new DBQuery(StateDaySummary, Seq(partialTime))
+
+  val partialQueryMapAQL =
+    s"""
+       |use dataverse twitter
+       |let $$common := (
+       |for $$t in dataset ds_tweet_
+       |
+       |where
+       |
+       |(get-interval-start($$t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+       |and get-interval-start($$t.timeBin) < datetime("$formatNow"))
+       |
+       |
+       |return $$t
+       |)
+       |
+       |let $$map := (
+       |for $$t in $$common
+       |
+       |group by $$c := $$t.stateID with $$t
+       |return { "key": string($$c) , "count": sum(for $$x in $$t return $$x.tweetCount) }
+       |
+       |)
+       |return $$map;
+     """.stripMargin.trim
+  val partialQueryTimeAQL =
+    s"""
+       |use dataverse twitter
+       |let $$common := (
+       |for $$t in dataset ds_tweet_
+       |
+       |where
+       |
+       |(get-interval-start($$t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+       |and get-interval-start($$t.timeBin) < datetime("$formatNow"))
+       |
+       |
+       |return $$t
+       |)
+       |
+       |let $$time := (
+       |for $$t in $$common
+       |
+       |group by $$c := print-datetime(get-interval-start($$t.timeBin), "YYYY-MM-DD") with $$t
+       |return { "key" : $$c, "count": sum(for $$x in $$t return $$x.tweetCount)}
+       |
+       |)
+       |return $$time
+     """.stripMargin.trim
+  val partialQueryHashtagAQL =
+    s"""
+       |use dataverse twitter
+       |let $$common := (
+       |for $$t in dataset ds_tweet_
+       |
+       |where
+       |
+       |(get-interval-start($$t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+       |and get-interval-start($$t.timeBin) < datetime("$formatNow"))
+       |
+       |
+       |return $$t
+       |)
+       |
+       |let $$hashtag := (
+       |for $$t in $$common
+       |
+       |for $$h in $$t.topHashTags
+       |group by $$tag := $$h.tag with $$h
+       |let $$c := sum(for $$x in $$h return $$x.count)
+       |order by $$c desc
+       |limit 50
+       |return { "key": $$tag, "count" : $$c}
+       |
+       |)
+       |return $$hashtag
+     """.stripMargin.trim
+
+  val partialQueryAQL2JsonMap = Seq(partialQueryMapAQL -> Seq(stateResult),
+                                    partialQueryTimeAQL -> Seq(dayResult),
+                                    partialQueryHashtagAQL -> Seq(hashTagResult)).toMap.mapValues(Json.toJson(_))
 
   // Create a finner summary level db query
   val finerQuery = new DBQuery(SummaryLevel(SpatialLevels.City, TimeLevels.Second), Seq(timePredicate1))

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TestData.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TestData.scala
@@ -42,14 +42,109 @@ trait TestData {
   val dayResult = Seq[KeyCountPair](KeyCountPair("2012-01-01", 1), KeyCountPair("2012-01-02", 2))
   val hashTagResult = Seq[KeyCountPair](KeyCountPair("youShallPass", 100))
   val byStateByDayResult = SpatialTimeCount(stateResult, dayResult, hashTagResult)
-  val byStateByDayResponse = Seq(Seq(stateResult), Seq(dayResult), Seq(hashTagResult)).map(Json.toJson(_))
+  val byStateByDateMapAQL =
+    s"""
+       |
+       |use dataverse twitter
+       |let $$common := (
+       |for $$t in dataset ds_tweet_
+       |
+       |where
+       |
+       |(get-interval-start($$t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+       |and get-interval-start($$t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
+       |
+       |
+       |
+       |let $$set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+       |for $$sid in $$set
+       |where $$t.stateID = $$sid
+       |
+       |return $$t
+       |)
+       |
+       |let $$map := (
+       |for $$t in $$common
+       |
+       |group by $$c := $$t.stateID with $$t
+       |return { "key": string($$c) , "count": sum(for $$x in $$t return $$x.tweetCount) }
+       |
+       |)
+       |return $$map;
+     """.stripMargin.trim
+  val byStateByDayTimeAQL =
+    s"""
+       |use dataverse twitter
+       |let $$common := (
+       |for $$t in dataset ds_tweet_
+       |
+       |where
+       |
+        |(get-interval-start($$t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+       |and get-interval-start($$t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
+       |
+       |
+       |
+       |let $$set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+       |for $$sid in $$set
+       |where $$t.stateID = $$sid
+       |
+       |return $$t
+       |)
+       |
+       |let $$time := (
+       |for $$t in $$common
+       |
+       |group by $$c := print-datetime(get-interval-start($$t.timeBin), "YYYY-MM-DD") with $$t
+       |return { "key" : $$c, "count": sum(for $$x in $$t return $$x.tweetCount)}
+       |
+       |)
+       |return $$time
+     """.stripMargin.trim
+  val byStateByDayHashtagAQL =
+    s"""
+       |use dataverse twitter
+       |let $$common := (
+       |for $$t in dataset ds_tweet_
+       |
+       |where
+       |
+       |(get-interval-start($$t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+       |and get-interval-start($$t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
+       |
+       |
+       |
+       |let $$set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+       |for $$sid in $$set
+       |where $$t.stateID = $$sid
+       |
+       |return $$t
+       |)
+       |
+       |let $$hashtag := (
+       |for $$t in $$common
+       |
+       |for $$h in $$t.topHashTags
+       |group by $$tag := $$h.tag with $$h
+       |let $$c := sum(for $$x in $$h return $$x.count)
+       |order by $$c desc
+       |limit 50
+       |return { "key": $$tag, "count" : $$c}
+       |
+       |)
+       |return $$hashtag
+     """.stripMargin.trim
+  val byStateByDayAQLMap = Seq(byStateByDateMapAQL -> Seq(stateResult),
+                               byStateByDayTimeAQL -> Seq(dayResult),
+                               byStateByDayHashtagAQL -> Seq(hashTagResult)).toMap.mapValues(Json.toJson(_))
 
   // Create by county, by month request
   val CountyMonthSummary = SummaryLevel(SpatialLevels.County, TimeLevels.Month)
   val byCountyMonthQuery = new DBQuery(CountyMonthSummary, Seq(timePredicate1, idPredicate))
   val monthResult = Seq[KeyCountPair](KeyCountPair("2012-01", 1), KeyCountPair("2012--02", 2))
   val byCountyMonthResult = SpatialTimeCount(stateResult, monthResult, hashTagResult)
-  val byCountyMonthResponse = Seq(Seq(stateResult), Seq(monthResult), Seq(hashTagResult)).map(Json.toJson(_))
+  val byCountyMonthAQLMap = Seq("map" -> Seq(stateResult), "day" -> Seq(monthResult), "hash" -> Seq(hashTagResult))
+    .toMap.mapValues(Json.toJson(_))
 
   val emptyKeyCountResponse = Json.toJson(Seq(Seq.empty[KeyCountPair]))
 

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterCountyDaySummaryViewTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterCountyDaySummaryViewTest.scala
@@ -47,7 +47,7 @@ class TwitterCountyDaySummaryViewTest extends TestkitExample with SpecificationL
       runSummaryView(byCountyMonthQuery, byCountyMonthAQLMap, byCountyMonthResult)
     }
     "split the query to ask the source if can not answer by view only" in {
-      withQueryAQLConn(byStateByDayAQLMap) { conn =>
+      withQueryAQLConn(partialQueryAQL2JsonMap) { conn =>
         val viewActor = system.actorOf(Props(classOf[TwitterCountyDaySummaryView],
                                              conn, queryUpdateTemp, probeSource.ref, fViewRecord, cloudberryConfig, ec))
         probeSender.send(viewActor, partialQuery)

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterCountyDaySummaryViewTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterCountyDaySummaryViewTest.scala
@@ -28,9 +28,9 @@ class TwitterCountyDaySummaryViewTest extends TestkitExample with SpecificationL
     val probeSender = new TestProbe(system)
     val probeSource = new TestProbe(system)
 
-    def runSummaryView(dbQuery: DBQuery, jsResponses: Seq[JsValue], result: SpatialTimeCount): MatchResult[Any] = {
+    def runSummaryView(dbQuery: DBQuery, aql2json: Map[String,JsValue], result: SpatialTimeCount): MatchResult[Any] = {
 
-      withQueryAQLConn(jsResponses) { conn =>
+      withQueryAQLConn(aql2json) { conn =>
         val viewActor = system.actorOf(Props(classOf[TwitterCountyDaySummaryView],
                                              conn, queryUpdateTemp, probeSource.ref, fViewRecord, cloudberryConfig, ec))
         probeSender.send(viewActor, dbQuery)
@@ -41,13 +41,13 @@ class TwitterCountyDaySummaryViewTest extends TestkitExample with SpecificationL
     }
 
     "answer the state summary query by aggregate those counties" in {
-      runSummaryView(byStateByDayQuery, byStateByDayResponse, byStateByDayResult)
+      runSummaryView(byStateByDayQuery, byStateByDayAQLMap, byStateByDayResult)
     }
     "answer the month summary query by aggregate those days " in {
-      runSummaryView(byCountyMonthQuery, byCountyMonthResponse, byCountyMonthResult)
+      runSummaryView(byCountyMonthQuery, byCountyMonthAQLMap, byCountyMonthResult)
     }
     "split the query to ask the source if can not answer by view only" in {
-      withQueryAQLConn(byStateByDayResponse) { conn =>
+      withQueryAQLConn(byStateByDayAQLMap) { conn =>
         val viewActor = system.actorOf(Props(classOf[TwitterCountyDaySummaryView],
                                              conn, queryUpdateTemp, probeSource.ref, fViewRecord, cloudberryConfig, ec))
         probeSender.send(viewActor, partialQuery)

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterCountyDaySummaryViewTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterCountyDaySummaryViewTest.scala
@@ -90,106 +90,111 @@ class TwitterCountyDaySummaryViewTest extends TestkitExample with SpecificationL
   "TwitterCountyDaySummaryView#generateAQL" should {
     "as expected" in {
       val dbQuery = new DBQuery(new SummaryLevel(SpatialLevels.State, TimeLevels.Day), Seq(idPredicate, keywordPredicate2, timePredicate2))
-      val aql = TwitterCountyDaySummaryView.generateAQL(dbQuery)
-      aql.trim must_== ("""use dataverse twitter
-                          |let $common := (
-                          |for $t in dataset ds_tweet_
-                          |
-                          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
-                          |for $sid in $set
-                          |where $t.stateID = $sid
-                          |
-                          |
-                          |
-                          |where
-                          |
-                          |(get-interval-start($t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
-                          |and get-interval-start($t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
-                          |or
-                          |(get-interval-start($t.timeBin) >= datetime("2016-01-01T00:00:00.000Z")
-                          |and get-interval-start($t.timeBin) < datetime("2016-01-15T00:00:00.000Z"))
-                          |
-                          |
-                          |return $t
-                          |)
-                          |
-                          |let $map := (
-                          |for $t in $common
-                          |
-                          |group by $c := $t.stateID with $t
-                          |return { "key": string($c) , "count": sum(for $x in $t return $x.tweetCount) }
-                          |
-                          |)
-                          |return $map;
-                          |
-                          |
-                          |use dataverse twitter
-                          |let $common := (
-                          |for $t in dataset ds_tweet_
-                          |
-                          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
-                          |for $sid in $set
-                          |where $t.stateID = $sid
-                          |
-                          |
-                          |
-                          |where
-                          |
-                          |(get-interval-start($t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
-                          |and get-interval-start($t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
-                          |or
-                          |(get-interval-start($t.timeBin) >= datetime("2016-01-01T00:00:00.000Z")
-                          |and get-interval-start($t.timeBin) < datetime("2016-01-15T00:00:00.000Z"))
-                          |
-                          |
-                          |return $t
-                          |)
-                          |
-                          |let $time := (
-                          |for $t in $common
-                          |
-                          |group by $c := print-datetime(get-interval-start($t.timeBin), "YYYY-MM-DD") with $t
-                          |return { "key" : $c, "count": sum(for $x in $t return $x.tweetCount)}
-                          |
-                          |)
-                          |return $time
-                          |
-                          |
-                          |use dataverse twitter
-                          |let $common := (
-                          |for $t in dataset ds_tweet_
-                          |
-                          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
-                          |for $sid in $set
-                          |where $t.stateID = $sid
-                          |
-                          |
-                          |
-                          |where
-                          |
-                          |(get-interval-start($t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
-                          |and get-interval-start($t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
-                          |or
-                          |(get-interval-start($t.timeBin) >= datetime("2016-01-01T00:00:00.000Z")
-                          |and get-interval-start($t.timeBin) < datetime("2016-01-15T00:00:00.000Z"))
-                          |
-                          |
-                          |return $t
-                          |)
-                          |
-                          |let $hashtag := (
-                          |for $t in $common
-                          |
-                          |for $h in $t.topHashTags
-                          |group by $tag := $h.tag with $h
-                          |let $c := sum(for $x in $h return $x.count)
-                          |order by $c desc
-                          |limit 50
-                          |return { "key": $tag, "count" : $c}
-                          |
-                          |)
-                          |return $hashtag
-                          | """.stripMargin.trim)
+      TwitterCountyDaySummaryView.generateByMapAQL(dbQuery).trim must_==
+        """
+          |use dataverse twitter
+          |let $common := (
+          |for $t in dataset ds_tweet_
+          |
+          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+          |for $sid in $set
+          |where $t.stateID = $sid
+          |
+          |
+          |
+          |where
+          |
+          |(get-interval-start($t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+          |and get-interval-start($t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
+          |or
+          |(get-interval-start($t.timeBin) >= datetime("2016-01-01T00:00:00.000Z")
+          |and get-interval-start($t.timeBin) < datetime("2016-01-15T00:00:00.000Z"))
+          |
+          |
+          |return $t
+          |)
+          |
+          |let $map := (
+          |for $t in $common
+          |
+          |group by $c := $t.stateID with $t
+          |return { "key": string($c) , "count": sum(for $x in $t return $x.tweetCount) }
+          |
+          |)
+          |return $map;
+          |""".stripMargin.trim
+
+      TwitterCountyDaySummaryView.generateByTimeAQL(dbQuery).trim must_== (
+        """
+          |use dataverse twitter
+          |let $common := (
+          |for $t in dataset ds_tweet_
+          |
+          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+          |for $sid in $set
+          |where $t.stateID = $sid
+          |
+          |
+          |
+          |where
+          |
+          |(get-interval-start($t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+          |and get-interval-start($t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
+          |or
+          |(get-interval-start($t.timeBin) >= datetime("2016-01-01T00:00:00.000Z")
+          |and get-interval-start($t.timeBin) < datetime("2016-01-15T00:00:00.000Z"))
+          |
+          |
+          |return $t
+          |)
+          |
+          |let $time := (
+          |for $t in $common
+          |
+          |group by $c := print-datetime(get-interval-start($t.timeBin), "YYYY-MM-DD") with $t
+          |return { "key" : $c, "count": sum(for $x in $t return $x.tweetCount)}
+          |
+          |)
+          |return $time
+          |""".stripMargin.trim)
+
+      TwitterCountyDaySummaryView.generateByHashtagAQL(dbQuery).trim must_== (
+        """
+          |use dataverse twitter
+          |let $common := (
+          |for $t in dataset ds_tweet_
+          |
+          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+          |for $sid in $set
+          |where $t.stateID = $sid
+          |
+          |
+          |
+          |where
+          |
+          |(get-interval-start($t.timeBin) >= datetime("2012-01-01T00:00:00.000Z")
+          |and get-interval-start($t.timeBin) < datetime("2012-01-08T00:00:00.000Z"))
+          |or
+          |(get-interval-start($t.timeBin) >= datetime("2016-01-01T00:00:00.000Z")
+          |and get-interval-start($t.timeBin) < datetime("2016-01-15T00:00:00.000Z"))
+          |
+          |
+          |return $t
+          |)
+          |
+          |let $hashtag := (
+          |for $t in $common
+          |
+          |for $h in $t.topHashTags
+          |group by $tag := $h.tag with $h
+          |let $c := sum(for $x in $h return $x.count)
+          |order by $c desc
+          |limit 50
+          |return { "key": $tag, "count" : $c}
+          |
+          |)
+          |return $hashtag
+          |""".stripMargin.trim)
     }
 
   }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterDataStoreActorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterDataStoreActorTest.scala
@@ -9,111 +9,117 @@ class TwitterDataStoreActorTest extends Specification with TestData {
     "generateAQL" in {
 
       val dbQuery = new DBQuery(TwitterCountyDaySummaryView.SummaryLevel, Seq(idPredicate, keywordPredicate2, timePredicate2))
-      val str = TwitterDataStoreActor.generateAQL("ds_tweet", dbQuery)
-      str.trim must_== ("""use dataverse twitter
-                          |let $common := (
-                          |for $t in dataset ds_tweet
-                          |
-                          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
-                          |for $sid in $set
-                          |where $t.geo_tag.stateID = $sid
-                          |
-                          |where similarity-jaccard(word-tokens($t."text"), word-tokens("trump")) > 0.0
-                          |and contains($t."text", "hilary")
-                          |
-                          |where
-                          |
-                          |($t."create_at">= datetime("2012-01-01T00:00:00.000Z")
-                          |and $t."create_at" <= datetime("2012-01-08T00:00:00.000Z"))
-                          |or
-                          |($t."create_at">= datetime("2016-01-01T00:00:00.000Z")
-                          |and $t."create_at" <= datetime("2016-01-15T00:00:00.000Z"))
-                          |
-                          |
-                          |return $t
-                          |)
-                          |
-                          |let $map := (
-                          |for $t in $common
-                          |
-                          |group by $c := $t.geo_tag.countyID with $t
-                          |return { "key": string($c) , "count": count($t) }
-                          |
-                          |)
-                          |return $map
-                          |
-                          |
-                          |use dataverse twitter
-                          |let $common := (
-                          |for $t in dataset ds_tweet
-                          |
-                          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
-                          |for $sid in $set
-                          |where $t.geo_tag.stateID = $sid
-                          |
-                          |where similarity-jaccard(word-tokens($t."text"), word-tokens("trump")) > 0.0
-                          |and contains($t."text", "hilary")
-                          |
-                          |where
-                          |
-                          |($t."create_at">= datetime("2012-01-01T00:00:00.000Z")
-                          |and $t."create_at" <= datetime("2012-01-08T00:00:00.000Z"))
-                          |or
-                          |($t."create_at">= datetime("2016-01-01T00:00:00.000Z")
-                          |and $t."create_at" <= datetime("2016-01-15T00:00:00.000Z"))
-                          |
-                          |
-                          |return $t
-                          |)
-                          |
-                          |let $time := (
-                          |for $t in $common
-                          |
-                          |group by $c := print-datetime($t.create_at, "YYYY-MM-DD") with $t
-                          |let $count := count($t)
-                          |return { "key" : $c , "count": $count }
-                          |
-                          |)
-                          |return $time
-                          |
-                          |
-                          |use dataverse twitter
-                          |let $common := (
-                          |for $t in dataset ds_tweet
-                          |
-                          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
-                          |for $sid in $set
-                          |where $t.geo_tag.stateID = $sid
-                          |
-                          |where similarity-jaccard(word-tokens($t."text"), word-tokens("trump")) > 0.0
-                          |and contains($t."text", "hilary")
-                          |
-                          |where
-                          |
-                          |($t."create_at">= datetime("2012-01-01T00:00:00.000Z")
-                          |and $t."create_at" <= datetime("2012-01-08T00:00:00.000Z"))
-                          |or
-                          |($t."create_at">= datetime("2016-01-01T00:00:00.000Z")
-                          |and $t."create_at" <= datetime("2016-01-15T00:00:00.000Z"))
-                          |
-                          |
-                          |return $t
-                          |)
-                          |
-                          |let $hashtag := (
-                          |for $t in $common
-                          |where not(is-null($t.hashtags))
-                          |
-                          |for $h in $t.hashtags
-                          |group by $tag := $h with $h
-                          |let $c := count($h)
-                          |order by $c desc
-                          |limit 50
-                          |return { "key": $tag, "count" : $c}
-                          |
-                          |)
-                          |return $hashtag
-                          | """.stripMargin.trim)
+      TwitterDataStoreActor.generateByMapAQL("ds_tweet", dbQuery).trim must_== (
+        """use dataverse twitter
+          |let $common := (
+          |for $t in dataset ds_tweet
+          |
+          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+          |for $sid in $set
+          |where $t.geo_tag.stateID = $sid
+          |
+          |where similarity-jaccard(word-tokens($t."text"), word-tokens("trump")) > 0.0
+          |and contains($t."text", "hilary")
+          |
+          |where
+          |
+          |($t."create_at">= datetime("2012-01-01T00:00:00.000Z")
+          |and $t."create_at" <= datetime("2012-01-08T00:00:00.000Z"))
+          |or
+          |($t."create_at">= datetime("2016-01-01T00:00:00.000Z")
+          |and $t."create_at" <= datetime("2016-01-15T00:00:00.000Z"))
+          |
+          |
+          |return $t
+          |)
+          |
+          |let $map := (
+          |for $t in $common
+          |
+          |group by $c := $t.geo_tag.countyID with $t
+          |return { "key": string($c) , "count": count($t) }
+          |
+          |)
+          |return $map
+          | """.stripMargin.trim)
+
+      TwitterDataStoreActor.generateByTimeAQL("ds_tweet", dbQuery).trim must_== (
+        """
+          |use dataverse twitter
+          |let $common := (
+          |for $t in dataset ds_tweet
+          |
+          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
+          |for $sid in $set
+          |where $t.geo_tag.stateID = $sid
+          |
+          |where similarity-jaccard(word-tokens($t."text"), word-tokens("trump")) > 0.0
+          |and contains($t."text", "hilary")
+          |
+          |where
+          |
+          |($t."create_at">= datetime("2012-01-01T00:00:00.000Z")
+          |and $t."create_at" <= datetime("2012-01-08T00:00:00.000Z"))
+          |or
+          |($t."create_at">= datetime("2016-01-01T00:00:00.000Z")
+          |and $t."create_at" <= datetime("2016-01-15T00:00:00.000Z"))
+          |
+          |
+          |return $t
+          |)
+          |
+          |let $time := (
+          |for $t in $common
+          |
+          |group by $c := print-datetime($t.create_at, "YYYY-MM-DD") with $t
+          |let $count := count($t)
+          |return { "key" : $c , "count": $count }
+          |
+          |)
+          |return $time
+          | """.stripMargin.trim)
+
+      TwitterDataStoreActor.generateByHashtagAQL("ds_tweet", dbQuery).trim must_== (
+        """
+          |use dataverse twitter
+          | let $common := (
+          | for $t in dataset ds_tweet
+          |
+          | let $set :=[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50]
+          | for $sid in $set
+          | where $t.geo_tag.stateID = $sid
+          |
+          | where similarity - jaccard(word - tokens($t."text"), word - tokens("trump")) > 0.0
+          | and contains($t."text", "hilary")
+          |
+          | where
+          |
+          |($t."create_at" >= datetime("2012-01-01T00:00:00.000Z")
+          | and $t."create_at" <= datetime("2012-01-08T00:00:00.000Z"))
+          | or
+          |($t."create_at" >= datetime("2016-01-01T00:00:00.000Z")
+          | and $t."create_at" <= datetime("2016-01-15T00:00:00.000Z"))
+          |
+          |
+          | return $t
+          |)
+          |
+          | let $hashtag := (
+          | for $t in $common
+          | where not(is - null ($t.hashtags))
+          |
+          | for $h in $t.hashtags
+          | group by $tag := $h with $h
+          | let $c := count($h)
+          | order by $c desc
+          | limit 50
+          | return {
+          |"key": $tag, "count": $c
+          | }
+          |
+          |)
+          | return $hashtag
+          | """.stripMargin.trim)
     }
 
   }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterDataStoreActorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterDataStoreActorTest.scala
@@ -91,19 +91,19 @@ class TwitterDataStoreActorTest extends Specification with TestData {
           |let $common := (
           |for $t in dataset ds_tweet
           |
-          |let $set :=[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50]
+          |let $set := [ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50 ]
           |for $sid in $set
           |where $t.geo_tag.stateID = $sid
           |
-          |where similarity - jaccard(word - tokens($t."text"), word - tokens("trump")) > 0.0
+          |where similarity-jaccard(word-tokens($t."text"), word-tokens("trump")) > 0.0
           |and contains($t."text", "hilary")
           |
           |where
           |
-          |($t."create_at" >= datetime("2012-01-01T00:00:00.000Z")
+          |($t."create_at">= datetime("2012-01-01T00:00:00.000Z")
           |and $t."create_at" <= datetime("2012-01-08T00:00:00.000Z"))
           |or
-          |($t."create_at" >= datetime("2016-01-01T00:00:00.000Z")
+          |($t."create_at">= datetime("2016-01-01T00:00:00.000Z")
           |and $t."create_at" <= datetime("2016-01-15T00:00:00.000Z"))
           |
           |
@@ -112,19 +112,17 @@ class TwitterDataStoreActorTest extends Specification with TestData {
           |
           |let $hashtag := (
           |for $t in $common
-          |where not(is - null ($t.hashtags))
+          |where not(is-null($t.hashtags))
           |
           |for $h in $t.hashtags
           |group by $tag := $h with $h
           |let $c := count($h)
           |order by $c desc
           |limit 50
-          |return {
-          |"key": $tag, "count": $c
-          |}
+          |return { "key": $tag, "count" : $c}
           |
           |)
-          | return $hashtag
+          |return $hashtag
           | """.stripMargin.trim)
     }
 

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterDataStoreActorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterDataStoreActorTest.scala
@@ -6,11 +6,12 @@ import org.specs2.mutable.Specification
 class TwitterDataStoreActorTest extends Specification with TestData {
 
   "TwitterDataStoreActorTest" should {
-    "generateAQL" in {
+    val dbQuery = new DBQuery(TwitterCountyDaySummaryView.SummaryLevel, Seq(idPredicate, keywordPredicate2, timePredicate2))
+    "generateMapAQL" in {
 
-      val dbQuery = new DBQuery(TwitterCountyDaySummaryView.SummaryLevel, Seq(idPredicate, keywordPredicate2, timePredicate2))
       TwitterDataStoreActor.generateByMapAQL("ds_tweet", dbQuery).trim must_== (
-        """use dataverse twitter
+        """
+          |use dataverse twitter
           |let $common := (
           |for $t in dataset ds_tweet
           |
@@ -42,6 +43,9 @@ class TwitterDataStoreActorTest extends Specification with TestData {
           |)
           |return $map
           | """.stripMargin.trim)
+    }
+
+    "generateTimeAQL" in {
 
       TwitterDataStoreActor.generateByTimeAQL("ds_tweet", dbQuery).trim must_== (
         """
@@ -78,44 +82,46 @@ class TwitterDataStoreActorTest extends Specification with TestData {
           |)
           |return $time
           | """.stripMargin.trim)
+    }
 
+    "generateHashtagAQL" in {
       TwitterDataStoreActor.generateByHashtagAQL("ds_tweet", dbQuery).trim must_== (
         """
           |use dataverse twitter
-          | let $common := (
-          | for $t in dataset ds_tweet
+          |let $common := (
+          |for $t in dataset ds_tweet
           |
-          | let $set :=[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50]
-          | for $sid in $set
-          | where $t.geo_tag.stateID = $sid
+          |let $set :=[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50]
+          |for $sid in $set
+          |where $t.geo_tag.stateID = $sid
           |
-          | where similarity - jaccard(word - tokens($t."text"), word - tokens("trump")) > 0.0
-          | and contains($t."text", "hilary")
+          |where similarity - jaccard(word - tokens($t."text"), word - tokens("trump")) > 0.0
+          |and contains($t."text", "hilary")
           |
-          | where
+          |where
           |
           |($t."create_at" >= datetime("2012-01-01T00:00:00.000Z")
-          | and $t."create_at" <= datetime("2012-01-08T00:00:00.000Z"))
-          | or
+          |and $t."create_at" <= datetime("2012-01-08T00:00:00.000Z"))
+          |or
           |($t."create_at" >= datetime("2016-01-01T00:00:00.000Z")
-          | and $t."create_at" <= datetime("2016-01-15T00:00:00.000Z"))
+          |and $t."create_at" <= datetime("2016-01-15T00:00:00.000Z"))
           |
           |
-          | return $t
+          |return $t
           |)
           |
-          | let $hashtag := (
-          | for $t in $common
-          | where not(is - null ($t.hashtags))
+          |let $hashtag := (
+          |for $t in $common
+          |where not(is - null ($t.hashtags))
           |
-          | for $h in $t.hashtags
-          | group by $tag := $h with $h
-          | let $c := count($h)
-          | order by $c desc
-          | limit 50
-          | return {
+          |for $h in $t.hashtags
+          |group by $tag := $h with $h
+          |let $c := count($h)
+          |order by $c desc
+          |limit 50
+          |return {
           |"key": $tag, "count": $c
-          | }
+          |}
           |
           |)
           | return $hashtag

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterKeywordViewActorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterKeywordViewActorTest.scala
@@ -23,8 +23,7 @@ class TwitterKeywordViewActorTest extends TestkitExample with SpecificationLike 
       val probeSender = new TestProbe(system)
       val probeSource = new TestProbe(system)
 
-
-      val answerAql =
+      val answerAqls = Seq(
         """
           |use dataverse twitter
           |let $common := (
@@ -52,8 +51,9 @@ class TwitterKeywordViewActorTest extends TestkitExample with SpecificationLike 
           |
           |)
           |return $map
-          |
-          |
+          | """.stripMargin
+        ,
+        """
           |use dataverse twitter
           |let $common := (
           |for $t in dataset twitter_trump
@@ -81,8 +81,9 @@ class TwitterKeywordViewActorTest extends TestkitExample with SpecificationLike 
           |
           |)
           |return $time
-          |
-          |
+          | """.stripMargin
+        ,
+        """
           |use dataverse twitter
           |let $common := (
           |for $t in dataset twitter_trump
@@ -115,7 +116,8 @@ class TwitterKeywordViewActorTest extends TestkitExample with SpecificationLike 
           |)
           |return $hashtag
           | """.stripMargin
-      withAqlCheckConn(answerAql) { conn =>
+      )
+      withQueryAQLConn(answerAqls.map(aql => aql.trim -> emptyKeyCountResponse).toMap) { conn =>
         val viewActor = system.actorOf(Props(classOf[TwitterKeywordViewActor],
                                              conn, queryTemplate, key, probeSource.ref, fViewRecord, cloudberryConfig, ec))
         probeSender.send(viewActor, keywordQuery1)
@@ -133,7 +135,7 @@ class TwitterKeywordViewActorTest extends TestkitExample with SpecificationLike 
       val probeSource = new TestProbe(system)
 
 
-      val answerAql =
+      val answerAqls = Seq(
         """
           |use dataverse twitter
           |let $common := (
@@ -162,8 +164,9 @@ class TwitterKeywordViewActorTest extends TestkitExample with SpecificationLike 
           |
           |)
           |return $map
-          |
-          |
+          | """.stripMargin
+        ,
+        """
           |use dataverse twitter
           |let $common := (
           |for $t in dataset twitter_trump
@@ -192,8 +195,9 @@ class TwitterKeywordViewActorTest extends TestkitExample with SpecificationLike 
           |
           |)
           |return $time
-          |
-          |
+          | """.stripMargin
+        ,
+        """
           |use dataverse twitter
           |let $common := (
           |for $t in dataset twitter_trump
@@ -227,7 +231,8 @@ class TwitterKeywordViewActorTest extends TestkitExample with SpecificationLike 
           |)
           |return $hashtag
           | """.stripMargin
-      withAqlCheckConn(answerAql) { conn =>
+      )
+      withQueryAQLConn(answerAqls.map(aql => aql.trim -> emptyKeyCountResponse).toMap) { conn =>
         val viewActor = system.actorOf(Props(classOf[TwitterKeywordViewActor],
                                              conn, queryTemplate, key, probeSource.ref, fViewRecord, cloudberryConfig, ec))
         probeSender.send(viewActor, keywordQuery2)

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterViewsManagerActorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/asterix/TwitterViewsManagerActorTest.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.cloudberry.zion.asterix
 
-import edu.uci.ics.cloudberry.zion.actor.{TestUtil, ViewMetaRecord}
+import edu.uci.ics.cloudberry.zion.actor.{MockConnClient, TestUtil, ViewMetaRecord}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
@@ -13,17 +13,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class TwitterViewsManagerActorTest extends Specification with Mockito with TestData {
-
-  val mockConn = mock[AsterixConnection]
-  when(mockConn.post(any[String])).thenAnswer(new Answer[Future[String]] {
-    override def answer(invocation: InvocationOnMock): Future[String] = {
-      Future {
-        invocation.getArguments.head.asInstanceOf[String]
-      }
-    }
-  })
-
+class TwitterViewsManagerActorTest extends Specification with MockConnClient with TestData {
 
   "A TwitterViewsManagerActor" should {
     "load meta store after start " in {
@@ -42,8 +32,7 @@ class TwitterViewsManagerActorTest extends Specification with Mockito with TestD
 
   "TwitterViewsManagerActorTest Static Functions" should {
     "flushMetaToStore" in {
-      val faql = TwitterViewsManagerActor.flushMetaToStore(mockConn, testRecords)
-      Await.result(faql.mapTo[String], 100 millisecond).trim must_== (
+      val expectedAQL =
         """
           |use dataverse twitter
           |create type typeViewMeta2 if not exists as open {
@@ -89,7 +78,12 @@ class TwitterViewsManagerActorTest extends Specification with Mockito with TestD
           |  "visitTimes" : 20,
           |  "updateCycle" : 3600
           |} ]
-          |); """.stripMargin.trim)
+          |);
+          |""".stripMargin.trim
+      withUpdateAQLConn(Set(expectedAQL)) { conn =>
+        val fResult = TwitterViewsManagerActor.flushMetaToStore(conn, testRecords)
+        Await.result(fResult, 100 millisecond) must_== true
+      }
     }
 
     "generateSummaryViewAQL" in {
@@ -132,8 +126,8 @@ class TwitterViewsManagerActorTest extends Specification with Mockito with TestD
                           | """.stripMargin.trim)
     }
 
-    "loadFromeMetaStore" in {
-      TestUtil.withAsterixConn(Json.toJson(testRecords)) { conn =>
+    "loadFromMetaStore" in {
+      withQueryAQLConn(Seq(Json.toJson(testRecords))) { conn =>
         val faql = TwitterViewsManagerActor.loadFromMetaStore("ds_tweet", conn)
         Await.result(faql, 2 seconds) must_== (testRecords)
       }


### PR DESCRIPTION
Summary:

We send the `byTime`, `byMap`, and `byHashtag` aggregations in one AQL. The problem is that if one of it failed, the other part would also fail. The UI won't get updates. By the PR, we split this large AQL into three AQLs in parallel. Thus, the `zion` will still respond to `neo` even some of them failed.

Related Issue:
#88 

It looks big, but most of it is about corresponding tests utility changes.
@aishwaryakapse 