### PR TITLE
Make cloudberry reactive

### DIFF
--- a/neo/app/actor/NeoReactiveActor.scala
+++ b/neo/app/actor/NeoReactiveActor.scala
@@ -1,5 +1,30 @@
 package actor
 
-class NeoReactiveActor {
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import edu.uci.ics.cloudberry.zion.actor.ReactiveBerryClient
+import models.UserRequest
+import play.api.libs.json.{JsArray, JsError, JsValue, Json}
 
+class NeoReactiveActor(out: ActorRef, val berryClientProps: Props) extends Actor with ActorLogging {
+
+  val berryClient = context.watch(context.actorOf(berryClientProps))
+
+  override def receive: Receive = {
+    case json: JsValue =>
+      json.validate[UserRequest].map { userRequest =>
+        for (berryRequest <- NeoActor.generateCBerryRequest(userRequest)) {
+          if (berryRequest._1 == NeoActor.RequestType.ByPlace) {
+            val request = ReactiveBerryClient.Request(berryRequest._2,
+                                                      (json: JsArray) => Json.obj("key" -> berryRequest._1.toString, "value" -> json))
+            berryClient.tell(request, out)
+          }
+        }
+      }.recoverTotal {
+        e => sender ! JsError.toJson(e)
+      }
+  }
+}
+
+object NeoReactiveActor {
+  def props(out: ActorRef, berryClientProp: Props) = Props(new NeoReactiveActor(out, berryClientProp))
 }

--- a/neo/app/actor/NeoReactiveActor.scala
+++ b/neo/app/actor/NeoReactiveActor.scala
@@ -1,0 +1,5 @@
+package actor
+
+class NeoReactiveActor {
+
+}

--- a/neo/app/controllers/Application.scala
+++ b/neo/app/controllers/Application.scala
@@ -7,7 +7,7 @@ import akka.actor.{Actor, ActorSystem, DeadLetter, Props}
 import akka.stream.Materializer
 import akka.util.Timeout
 import db.Migration_20160814
-import edu.uci.ics.cloudberry.zion.actor.{Client, DataStoreManager}
+import edu.uci.ics.cloudberry.zion.actor.{DataStoreManager, RESTFulBerryClient}
 import edu.uci.ics.cloudberry.zion.common.Config
 import edu.uci.ics.cloudberry.zion.model.datastore.AsterixConn
 import edu.uci.ics.cloudberry.zion.model.impl.{AQLGenerator, JSONParser, QueryPlanner}
@@ -38,7 +38,7 @@ class Application @Inject()(val wsClient: WSClient,
 
   val manager = system.actorOf(DataStoreManager.props(Migration_20160814.berryMeta, asterixConn, AQLGenerator, config))
 
-  val berryProp = Client.props(new JSONParser(), manager, new QueryPlanner(), config)
+  val berryProp = RESTFulBerryClient.props(new JSONParser(), manager, new QueryPlanner(), config)
   val berryClient = system.actorOf(berryProp)
   val neoActor = system.actorOf(NeoActor.props(berryProp))
 

--- a/neo/app/controllers/Application.scala
+++ b/neo/app/controllers/Application.scala
@@ -2,12 +2,13 @@ package controllers
 
 import javax.inject.{Inject, Singleton}
 
-import actor.NeoActor
-import akka.actor.{Actor, ActorSystem, DeadLetter, Props}
-import akka.stream.Materializer
+import actor.{NeoActor, NeoReactiveActor}
+import akka.actor.{Actor, ActorSystem, DeadLetter, PoisonPill, Props}
+import akka.stream.{Materializer, OverflowStrategy}
+import akka.stream.scaladsl.Source
 import akka.util.Timeout
 import db.Migration_20160814
-import edu.uci.ics.cloudberry.zion.actor.{DataStoreManager, RESTFulBerryClient}
+import edu.uci.ics.cloudberry.zion.actor.{DataStoreManager, RESTFulBerryClient, ReactiveBerryClient}
 import edu.uci.ics.cloudberry.zion.common.Config
 import edu.uci.ics.cloudberry.zion.model.datastore.AsterixConn
 import edu.uci.ics.cloudberry.zion.model.impl.{AQLGenerator, JSONParser, QueryPlanner}
@@ -60,7 +61,9 @@ class Application @Inject()(val wsClient: WSClient,
   }
 
   def ws = WebSocket.accept[JsValue, JsValue] { request =>
-    ActorFlow.actorRef(out => NeoActor.props(out, berryProp))
+    //    ActorFlow.actorRef(out => NeoActor.props(out, berryProp))
+    val prop = ReactiveBerryClient.props(new JSONParser(), manager, new QueryPlanner(), config, 1000)
+    ActorFlow.actorRef(out => NeoReactiveActor.props(out, prop))
   }
 
   def tweet(id: String) = Action.async {

--- a/neo/conf/application.conf
+++ b/neo/conf/application.conf
@@ -85,6 +85,8 @@ view.update.interval = "30 minutes"
 
 view.meta.flush.interval = "30 minutes"
 
+berry.firstquery.gap = "2 days"
+
 asterixdb.url = "http://kiwi.ics.uci.edu:19002/aql"
 asterixdb.view.meta.name = "viewMeta"
 tweet.url = "http://twitter-search-proxy.herokuapp.com/search/tweets?q=%s"

--- a/neo/public/javascripts/common/services.js
+++ b/neo/public/javascripts/common/services.js
@@ -42,6 +42,7 @@ angular.module('cloudberry.common', [])
     ws.onmessage = function(event) {
       $timeout(function() {
         var result = JSONbig.parse(event.data);
+        console.log(result);
         switch (result.key) {
           case "byPlace":
             asterixService.mapResult = result.value;

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/DataStoreManager.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/DataStoreManager.scala
@@ -84,13 +84,15 @@ class DataStoreManager(metaDataset: String,
       }
     case create: CreateView => createView(create)
     case drop: DropView => ???
-    case askInfo: AskInfoMsg =>
+    case askInfo: AskInfoAndViews =>
       sender ! {
         metaData.get(askInfo.who) match {
           case Some(info) => info +: metaData.filter(_._2.createQueryOpt.exists(q => q.dataset == askInfo.who)).values.toList
           case None => Seq.empty
         }
       }
+    case askInfo: AskInfo =>
+      sender ! metaData.get(askInfo.who)
 
     case info: DataSetInfo =>
       metaData += info.name -> info
@@ -195,7 +197,9 @@ object DataStoreManager {
   }
 
 
-  case class AskInfoMsg(who: String)
+  case class AskInfoAndViews(who: String)
+
+  case class AskInfo(who: String)
 
   case class Register(dataset: String, schema: Schema)
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/DataStoreManager.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/DataStoreManager.scala
@@ -54,7 +54,7 @@ class DataStoreManager(metaDataset: String,
   def preparing: Receive = {
     case Prepared =>
       unstashAll()
-      context.become(normal)
+      context.become(normal, discardOld = true)
     case _ => stash()
   }
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClient.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClient.scala
@@ -3,25 +3,24 @@ package edu.uci.ics.cloudberry.zion.actor
 import akka.actor.{Actor, ActorRef, Props}
 import akka.pattern.ask
 import akka.util.Timeout
+import edu.uci.ics.cloudberry.zion.actor.DataStoreManager.AskInfoAndViews
 import edu.uci.ics.cloudberry.zion.common.Config
-import edu.uci.ics.cloudberry.zion.actor.DataStoreManager.AskInfoMsg
 import edu.uci.ics.cloudberry.zion.model.impl.{DataSetInfo, JSONParser, QueryPlanner}
 import edu.uci.ics.cloudberry.zion.model.schema.Query
-import play.api.libs.json.{JsArray, JsValue}
+import play.api.libs.json.JsValue
 
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * An Actor to serve the RESTFul request which will return one response for one request
   *
-  * @param out         the specific output actor replying to
   * @param jsonParser  the parser to parse the JSON request
   * @param dataManager the dataStoreManager
   * @param planner     the queryPlanner to optimize an efficient query work load to solve the request
   * @param config      the configuration
   * @param ec          implicit executionContext
   */
-class RESTFulBerryClient(val out: Option[ActorRef], val jsonParser: JSONParser, val dataManager: ActorRef, val planner: QueryPlanner, val config: Config)
+class RESTFulBerryClient(val jsonParser: JSONParser, val dataManager: ActorRef, val planner: QueryPlanner, val config: Config)
                         (implicit val ec: ExecutionContext) extends Actor {
 
   import RESTFulBerryClient._
@@ -36,10 +35,10 @@ class RESTFulBerryClient(val out: Option[ActorRef], val jsonParser: JSONParser, 
       solveQuery(query, sender())
   }
 
-  private def solveQuery(query: Query, curSender: ActorRef) = {
+  protected def solveQuery(query: Query, output: ActorRef) = {
     withDataSetInfo(query) {
       case seq if seq.isEmpty =>
-        out.getOrElse(curSender) ! NoSuchDataset(query.dataset)
+        output ! NoSuchDataset(query.dataset)
       case infos: Seq[DataSetInfo] =>
         val (queries, merger) = planner.makePlan(query, infos.head, infos.tail)
         val fResponse = Future.traverse(queries) { query =>
@@ -48,7 +47,7 @@ class RESTFulBerryClient(val out: Option[ActorRef], val jsonParser: JSONParser, 
 
         fResponse.map { responses =>
           val r = merger(responses)
-          out.getOrElse(curSender) ! r
+          output ! r
         }
 
         val newViews = planner.suggestNewView(query, infos.head, infos.tail)
@@ -58,7 +57,7 @@ class RESTFulBerryClient(val out: Option[ActorRef], val jsonParser: JSONParser, 
 
   protected def withDataSetInfo(query: Query)(block: Seq[DataSetInfo] => Unit): Unit = {
     //TODO replace the logic to visit a cache to alleviate dataManager's workload
-    dataManager ? AskInfoMsg(query.dataset) map {
+    dataManager ? AskInfoAndViews(query.dataset) map {
       case seq: Seq[_] if seq.forall(_.isInstanceOf[DataSetInfo]) =>
         block(seq.map(_.asInstanceOf[DataSetInfo]))
     }
@@ -67,14 +66,9 @@ class RESTFulBerryClient(val out: Option[ActorRef], val jsonParser: JSONParser, 
 
 object RESTFulBerryClient {
 
-  def props(out: ActorRef, jsonParser: JSONParser, dataManagerRef: ActorRef, planner: QueryPlanner, config: Config)
-           (implicit ec: ExecutionContext) = {
-    Props(new RESTFulBerryClient(Some(out), jsonParser, dataManagerRef, planner, config))
-  }
-
   def props(jsonParser: JSONParser, dataManagerRef: ActorRef, planner: QueryPlanner, config: Config)
            (implicit ec: ExecutionContext) = {
-    Props(new RESTFulBerryClient(None, jsonParser, dataManagerRef, planner, config))
+    Props(new RESTFulBerryClient(jsonParser, dataManagerRef, planner, config))
   }
 
   case class NoSuchDataset(name: String)

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClient.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClient.scala
@@ -11,10 +11,20 @@ import play.api.libs.json.{JsArray, JsValue}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class Client(val out: Option[ActorRef], val jsonParser: JSONParser, val dataManager: ActorRef, val planner: QueryPlanner, val config: Config)
-            (implicit val ec: ExecutionContext) extends Actor {
+/**
+  * An Actor to serve the RESTFul request which will return one response for one request
+  *
+  * @param out         the specific output actor replying to
+  * @param jsonParser  the parser to parse the JSON request
+  * @param dataManager the dataStoreManager
+  * @param planner     the queryPlanner to optimize an efficient query work load to solve the request
+  * @param config      the configuration
+  * @param ec          implicit executionContext
+  */
+class RESTFulBerryClient(val out: Option[ActorRef], val jsonParser: JSONParser, val dataManager: ActorRef, val planner: QueryPlanner, val config: Config)
+                        (implicit val ec: ExecutionContext) extends Actor {
 
-  import Client._
+  import RESTFulBerryClient._
 
   implicit val askTimeOut: Timeout = config.UserTimeOut
 
@@ -55,16 +65,16 @@ class Client(val out: Option[ActorRef], val jsonParser: JSONParser, val dataMana
   }
 }
 
-object Client {
+object RESTFulBerryClient {
 
   def props(out: ActorRef, jsonParser: JSONParser, dataManagerRef: ActorRef, planner: QueryPlanner, config: Config)
            (implicit ec: ExecutionContext) = {
-    Props(new Client(Some(out), jsonParser, dataManagerRef, planner, config))
+    Props(new RESTFulBerryClient(Some(out), jsonParser, dataManagerRef, planner, config))
   }
 
   def props(jsonParser: JSONParser, dataManagerRef: ActorRef, planner: QueryPlanner, config: Config)
            (implicit ec: ExecutionContext) = {
-    Props(new Client(None, jsonParser, dataManagerRef, planner, config))
+    Props(new RESTFulBerryClient(None, jsonParser, dataManagerRef, planner, config))
   }
 
   case class NoSuchDataset(name: String)

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClient.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClient.scala
@@ -11,9 +11,10 @@ import edu.uci.ics.cloudberry.zion.model.impl.QueryPlanner.IMerger
 import edu.uci.ics.cloudberry.zion.model.impl.{DataSetInfo, JSONParser, QueryPlanner}
 import edu.uci.ics.cloudberry.zion.model.schema._
 import org.joda.time.DateTime
-import play.api.libs.json.{JsArray, JsValue, Json}
+import play.api.libs.json.{JsArray, JsValue}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 /**
   * A reactive client which will continuously feed the result back to user
@@ -34,73 +35,99 @@ class ReactiveBerryClient(val jsonParser: JSONParser,
 
   val worker = childMaker(context, this)
 
-  //WARNING: all these evil mutable value SHALL NOT be read in the future thread
-  var curJson: JsValue = _
-  var curQuery: Query = _
-  var curInfo: DataSetInfo = _
-  var curSender: ActorRef = _
-  var curPostProp: (JsArray) => JsValue = _
-  var queryBoundary: TInterval = _
-  var accumulateResult: JsArray = _
-  var merger: IMerger = _
-  var lastAskTS: DateTime = _
+  private case class QueryInfo(query: Query, dataSetInfo: DataSetInfo, postTransform: IPostTransform, queryBound: TInterval, merger: IMerger)
+
+  private case class QueryGroup(ts: DateTime, curSender: ActorRef, queries: Seq[QueryInfo])
+
+  private case class Initial(ts: DateTime, sender: ActorRef, queries: Seq[Query], infos: Seq[DataSetInfo], postTransforms: Seq[IPostTransform])
+
+  private case class PartialResult(queryGroup: QueryGroup, jsons: Seq[JsArray])
+
+  //WARNING: Evil mutable value SHALL NOT be read/write in the future thread
+  var curKey: DateTime = _
 
   override def receive: Receive = {
     case request: Request =>
-      val query = jsonParser.parse(request.json)
-      val immutableSender = sender()
-      curSender = immutableSender
-      curJson = request.json
-      curPostProp = request.postProcess
-      dataManager ? AskInfo(query.dataset) map {
-        case Some(info: DataSetInfo) => self ! Initial(request.json, query, info)
-        case None => immutableSender ! NoSuchDataset(query.dataset)
+      val queries = request.requests.map(r => jsonParser.parse(r._1))
+      val curSender = sender()
+      val key = DateTime.now()
+      curKey = key
+      val fDataInfos = Future.traverse(queries) { query =>
+        dataManager ? AskInfo(query.dataset)
+      }.map(seq => seq.map(_.asInstanceOf[Option[DataSetInfo]]))
+
+      fDataInfos.map { seqInfos =>
+        if (seqInfos.exists(_.isEmpty)) {
+          curSender ! NoSuchDataset(queries(seqInfos.indexOf(None)).dataset)
+        } else {
+          self ! Initial(key, curSender, queries, seqInfos.map(_.get), request.requests.map(_._2))
+        }
       }
-    case initial: Initial if initial.json == curJson =>
-      log.info("initializing current json")
-      init(initial.query, initial.info)
+    case initial: Initial if initial.ts == curKey =>
+      val queryInfos = initial.queries.zip(initial.infos).zip(initial.postTransforms).map {
+        case ((query, info), trans) =>
+          val bound = query.getTimeInterval(info.schema.timeField).getOrElse(new TInterval(info.dataInterval.getStart, DateTime.now))
+          val merger = planner.calculateMergeFunc(query, info.schema)
+          val queryWOTime = query.copy(filter = query.filter.filterNot(_.fieldName == info.schema.timeField))
+          QueryInfo(queryWOTime, info, trans, bound, merger)
+      }
+      val min = queryInfos.map(_.queryBound.getStartMillis).min
+      val max = queryInfos.map(_.queryBound.getEndMillis).max
+      val boundary = new TInterval(min, max)
+
       val initialDuration = config.FirstQueryTimeGap.toMillis
-      val interval = calculateFirst(queryBoundary, initialDuration)
-      issueAQuery(interval)
-      context.become(askSlice(interval))
+      val interval = calculateFirst(boundary, initialDuration)
+      val queryGroup = QueryGroup(initial.ts, initial.sender, queryInfos)
+      val initResult = Seq.fill(queryInfos.size)(JsArray())
+      issueAQuery(interval, queryGroup)
+      context.become(askSlice(interval, boundary, queryGroup, initResult, askTime = DateTime.now), discardOld = true)
   }
 
-  private def init(query: Query, info: DataSetInfo): Unit = {
-    curQuery = query.copy(filter = query.filter.filterNot(_.fieldName == info.schema.timeField))
-    curInfo = info
-    queryBoundary = query.getTimeInterval(info.schema.timeField).getOrElse(new TInterval(info.dataInterval.getStart, DateTime.now))
-    accumulateResult = JsArray()
-    merger = planner.calculateMergeFunc(query, info.schema)
-    lastAskTS = DateTime.now
-  }
+  private def askSlice(curInterval: TInterval,
+                       boundary: TInterval,
+                       queryGroup: QueryGroup,
+                       accumulateResults: Seq[JsArray],
+                       askTime: DateTime): Receive = {
+    case result: PartialResult if result.queryGroup.ts == curKey =>
+      val mergedResults = queryGroup.queries.zipWithIndex.map { case (q, idx) =>
+        q.merger(Seq(accumulateResults(idx), result.jsons(idx)))
+      }
+      //TODO merge it as an array
+      mergedResults.zipWithIndex.foreach { case (ret, idx) =>
+        queryGroup.curSender ! queryGroup.queries(idx).postTransform.transform(ret)
+      }
 
-  private def askSlice(interval: TInterval): Receive = {
-    case result: PartialResult if result.query == curQuery =>
-      accumulateResult = merger(Seq(accumulateResult, result.json))
-      curSender ! curPostProp(accumulateResult)
-
-      val timeSpend = DateTime.now.getMillis - lastAskTS.getMillis
-      val nextInterval = calculateNext(interval, timeSpend)
+      val timeSpend = DateTime.now.getMillis - askTime.getMillis
+      val nextInterval = calculateNext(curInterval, timeSpend, boundary)
       if (nextInterval.toDurationMillis == 0) {
-        context.become(receive)
+        context.become(receive, discardOld = true)
       } else {
-        issueAQuery(nextInterval)
-        context.become(askSlice(nextInterval))
+        issueAQuery(nextInterval, queryGroup)
+        context.become(askSlice(nextInterval, boundary, queryGroup, mergedResults, DateTime.now), discardOld = true)
       }
     case newRequest: Request =>
       stash()
       unstashAll()
-      context.become(receive)
+      context.become(receive, discardOld = true)
   }
 
-  private def issueAQuery(interval: TInterval): Unit = {
-    lastAskTS = DateTime.now
-    val intervalFilter = FilterStatement(curInfo.schema.timeField, None, Relation.inRange,
-                                         Seq(interval.getStart, interval.getEnd).map(TimeField.TimeFormat.print))
-    val immutableQuery = curQuery.copy()
-    (worker ? curQuery.copy(filter = intervalFilter +: curQuery.filter)).map {
-      case result: JsArray =>
-        self ! PartialResult(immutableQuery, result)
+  //Main thread
+  private def issueAQuery(interval: TInterval, queryGroup: QueryGroup): Unit = {
+    val futures = Future.traverse(queryGroup.queries) { queryInfo =>
+      if (queryInfo.queryBound.overlaps(interval)) {
+        val overlaps = queryInfo.queryBound.overlap(interval)
+        val timeFilter = FilterStatement(queryInfo.dataSetInfo.schema.timeField, None, Relation.inRange,
+                                         Seq(overlaps.getStart, overlaps.getEnd).map(TimeField.TimeFormat.print))
+        worker ? queryInfo.query.copy(filter = timeFilter +: queryInfo.query.filter)
+      } else {
+        Future(JsArray())
+      }
+    }
+
+    futures.onComplete {
+      case Success(answers) =>
+        self ! PartialResult(queryGroup, answers.map(_.asInstanceOf[JsArray]))
+      case Failure(fails) => log.error(fails, "answer query failed")
     }
   }
 
@@ -109,9 +136,9 @@ class ReactiveBerryClient(val jsonParser: JSONParser,
     new TInterval(startTime, entireInterval.getEndMillis)
   }
 
-  private def calculateNext(interval: TInterval, timeSpend: Long): TInterval = {
+  private def calculateNext(interval: TInterval, timeSpend: Long, boundary: TInterval): TInterval = {
     val newDuration = (interval.toDurationMillis * responseTime / timeSpend.toDouble).toLong
-    val startTime = Math.max(queryBoundary.getStartMillis, interval.getStartMillis - newDuration)
+    val startTime = Math.max(boundary.getStartMillis, interval.getStartMillis - newDuration)
     new TInterval(startTime, interval.getStartMillis)
   }
 }
@@ -132,10 +159,14 @@ object ReactiveBerryClient {
     context.actorOf(RESTFulBerryClient.props(client.jsonParser, client.dataManager, client.planner, client.config))
   }
 
-  case class Request(json: JsValue, postProcess: (JsArray) => JsValue)
+  trait IPostTransform {
+    def transform(jsValue: JsValue): JsValue
+  }
 
-  case class Initial(json: JsValue, query: Query, info: DataSetInfo)
+  case object NoTransform extends IPostTransform {
+    override def transform(jsValue: JsValue): JsValue = jsValue
+  }
 
-  case class PartialResult(query: Query, json: JsArray)
+  case class Request(requests: Seq[(JsValue, IPostTransform)])
 
 }

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClient.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClient.scala
@@ -59,8 +59,7 @@ class ReactiveBerryClient(val jsonParser: JSONParser,
     case initial: Initial if initial.json == curJson =>
       log.info("initializing current json")
       init(initial.query, initial.info)
-      import scala.concurrent.duration._
-      val initialDuration = (30 days).toMillis
+      val initialDuration = config.FirstQueryTimeGap.toMillis
       val interval = calculateFirst(queryBoundary, initialDuration)
       issueAQuery(interval)
       context.become(askSlice(interval))

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClient.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClient.scala
@@ -1,0 +1,19 @@
+package edu.uci.ics.cloudberry.zion.actor
+
+import akka.actor.{Actor, ActorRef, Props}
+import edu.uci.ics.cloudberry.zion.common.Config
+import edu.uci.ics.cloudberry.zion.model.impl.{JSONParser, QueryPlanner}
+
+import scala.concurrent.ExecutionContext
+
+/**
+  * A reactive client which will continuously feed the result back to user
+  */
+class ReactiveBerryClient(val out: ActorRef, val jsonParser: JSONParser, val dataManager: ActorRef, val planner: QueryPlanner, val config: Config)
+                         (implicit val ec: ExecutionContext) extends Actor {
+  override def receive: Receive = ???
+}
+
+object ReactiveBerryClient {
+  def props() = ??? //Props(
+}

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClient.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClient.scala
@@ -1,19 +1,134 @@
 package edu.uci.ics.cloudberry.zion.actor
 
-import akka.actor.{Actor, ActorRef, Props}
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, Props, Stash}
+import akka.pattern.ask
+import akka.util.Timeout
+import edu.uci.ics.cloudberry.zion.TInterval
+import edu.uci.ics.cloudberry.zion.actor.DataStoreManager.AskInfo
+import edu.uci.ics.cloudberry.zion.actor.RESTFulBerryClient.NoSuchDataset
 import edu.uci.ics.cloudberry.zion.common.Config
-import edu.uci.ics.cloudberry.zion.model.impl.{JSONParser, QueryPlanner}
+import edu.uci.ics.cloudberry.zion.model.impl.QueryPlanner.IMerger
+import edu.uci.ics.cloudberry.zion.model.impl.{DataSetInfo, JSONParser, QueryPlanner}
+import edu.uci.ics.cloudberry.zion.model.schema._
+import org.joda.time.DateTime
+import play.api.libs.json.{JsArray, JsValue}
 
 import scala.concurrent.ExecutionContext
 
 /**
   * A reactive client which will continuously feed the result back to user
+  * One user should only attach to one ReactiveClient
   */
-class ReactiveBerryClient(val out: ActorRef, val jsonParser: JSONParser, val dataManager: ActorRef, val planner: QueryPlanner, val config: Config)
-                         (implicit val ec: ExecutionContext) extends Actor {
-  override def receive: Receive = ???
+class ReactiveBerryClient(val jsonParser: JSONParser,
+                          val dataManager: ActorRef,
+                          val planner: QueryPlanner,
+                          val config: Config,
+                          val responseTime: Long,
+                          childMaker: (ActorRefFactory, ReactiveBerryClient) => ActorRef
+                         )
+                         (implicit ec: ExecutionContext) extends Actor with Stash with ActorLogging {
+
+  import ReactiveBerryClient._
+
+  implicit val askTimeOut: Timeout = config.UserTimeOut
+
+  val worker = childMaker(context, this)
+
+  var curJson: JsValue = _
+  var curQuery: Query = _
+  var curInfo: DataSetInfo = _
+  var curSender: ActorRef = _
+  var queryBoundary: TInterval = _
+  var accumulateResult: JsArray = _
+  var merger: IMerger = _
+  var lastAskTS: DateTime = _
+
+  override def receive: Receive = {
+    case json: JsValue =>
+      val query = jsonParser.parse(json)
+      curSender = sender()
+      curJson = json
+      dataManager ? AskInfo(query.dataset) map {
+        case Some(info: DataSetInfo) => self ! Initial(json, query, info)
+        case None => curSender ! NoSuchDataset(query.dataset)
+      }
+    case initial: Initial if initial.json == curJson =>
+      init(initial.query, initial.info)
+      import scala.concurrent.duration._
+      val initialDuration = (30 days).toMillis
+      val interval = calculateFirst(queryBoundary, initialDuration)
+      issueAQuery(interval)
+      context.become(askSlice(interval))
+  }
+
+  private def init(query: Query, info: DataSetInfo): Unit = {
+    curQuery = query.copy(filter = query.filter.filterNot(_.fieldName == info.schema.timeField))
+    curInfo = info
+    queryBoundary = query.getTimeInterval(info.schema.timeField).getOrElse(new TInterval(info.dataInterval.getStart, DateTime.now))
+    accumulateResult = JsArray()
+    merger = planner.calculateMergeFunc(query, info.schema)
+    lastAskTS = DateTime.now
+  }
+
+  private def askSlice(interval: TInterval): Receive = {
+    case result: PartialResult if result.query == curQuery =>
+      accumulateResult = merger(Seq(accumulateResult, result.json))
+      curSender ! accumulateResult
+
+      val timeSpend = DateTime.now.getMillis - lastAskTS.getMillis
+      val nextInterval = calculateNext(interval, timeSpend)
+      if (nextInterval.toDurationMillis == 0) {
+        context.become(receive)
+      } else {
+        issueAQuery(nextInterval)
+        context.become(askSlice(nextInterval))
+      }
+    case json: JsValue =>
+      stash()
+      unstashAll()
+      context.become(receive)
+  }
+
+  private def issueAQuery(interval: TInterval): Unit = {
+    lastAskTS = DateTime.now
+    val intervalFilter = FilterStatement(curInfo.schema.timeField, None, Relation.inRange,
+                                         Seq(interval.getStart, interval.getEnd).map(TimeField.TimeFormat.print))
+    (worker ? curQuery.copy(filter = intervalFilter +: curQuery.filter)).map {
+      case result: JsArray =>
+        self ! PartialResult(curQuery.copy(), result)
+    }
+  }
+
+  private def calculateFirst(entireInterval: TInterval, gap: Long): TInterval = {
+    val startTime = Math.max(entireInterval.getEndMillis - gap, entireInterval.getStartMillis)
+    new TInterval(startTime, entireInterval.getEndMillis)
+  }
+
+  private def calculateNext(interval: TInterval, timeSpend: Long): TInterval = {
+    val newDuration = (interval.toDurationMillis * responseTime / timeSpend.toDouble).toLong
+    val startTime = Math.max(queryBoundary.getStartMillis, interval.getStartMillis - newDuration)
+    new TInterval(startTime, interval.getStartMillis)
+  }
 }
 
 object ReactiveBerryClient {
-  def props() = ??? //Props(
+  def props(jsonParser: JSONParser, dataManager: ActorRef, planner: QueryPlanner, config: Config, responseTime: Long)
+           (implicit ec: ExecutionContext) = {
+    Props(new ReactiveBerryClient(jsonParser, dataManager, planner, config, responseTime, defaultMaker))
+  }
+
+  def props(jsonParser: JSONParser, dataManager: ActorRef, planner: QueryPlanner, config: Config,
+            childMaker: (ActorRefFactory, ReactiveBerryClient) => ActorRef, responseTime: Long)
+           (implicit ec: ExecutionContext) = {
+    Props(new ReactiveBerryClient(jsonParser, dataManager, planner, config, responseTime, childMaker))
+  }
+
+  def defaultMaker(context: ActorRefFactory, client: ReactiveBerryClient)(implicit ec: ExecutionContext): ActorRef = {
+    context.actorOf(RESTFulBerryClient.props(client.jsonParser, client.dataManager, client.planner, client.config))
+  }
+
+  case class Initial(json: JsValue, query: Query, info: DataSetInfo)
+
+  case class PartialResult(query: Query, json: JsArray)
+
 }

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/common/Config.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/common/Config.scala
@@ -20,6 +20,8 @@ class Config(config: Configuration) {
 
   val DataManagerAppendViewTimeOut = config.getString("datamanager.timeout.appendview").map(parseTimePair).getOrElse(1 day)
 
+  val FirstQueryTimeGap = config.getString("berry.firstquery.gap").map(parseTimePair).getOrElse(2 days)
+
 }
 
 object Config {

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGenerator.scala
@@ -36,7 +36,7 @@ class AQLGenerator extends IQLGenerator {
     val createDataSet =
       s"""
          |drop dataset ${create.dataset} if exists;
-         |create dataset ${create.dataset}(${resultSchema.typeName}) primary key ${resultSchema.primaryKey.mkString(",")}
+         |create dataset ${create.dataset}(${resultSchema.typeName}) primary key ${resultSchema.primaryKey.mkString(",")} with filter on '${resultSchema.timeField}'
          |""".stripMargin
     val insert =
       s"""

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlanner.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlanner.scala
@@ -87,8 +87,8 @@ class QueryPlanner {
     bestView match {
       case None => (Seq(query), Unioner)
       case Some(view) =>
-        val queryInterval = query.getTimeInterval(source.schema.timeField).getOrElse(new Interval(source.stats.createTime, DateTime.now()))
-        val viewInterval = new Interval(source.stats.createTime, view.stats.lastModifyTime)
+        val queryInterval = query.getTimeInterval(source.schema.timeField).getOrElse(new Interval(new DateTime(0), DateTime.now()))
+        val viewInterval = new Interval(new DateTime(0), view.stats.lastModifyTime)
         val unCovered = getUnCoveredInterval(viewInterval, queryInterval)
 
         val seqBuilder = Seq.newBuilder[Query]

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/package.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/package.scala
@@ -1,8 +1,5 @@
 package edu.uci.ics.cloudberry
 
-//TODO this package is supposed to handle all kinds of SelectGroupAggregation queries.
-//Currently we are exploring the twitter related logic in the neo module.
-// We should generalize such requirement and extends the common logic to here.
 package object zion {
-
+  type TInterval = org.joda.time.Interval
 }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/DataStoreManagerTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/DataStoreManagerTest.scala
@@ -58,11 +58,11 @@ class DataStoreManagerTest extends TestkitExample with SpecificationLike with Mo
       metaQuery.asInstanceOf[Query].dataset must_== metaDataSet
       meta.reply(initialInfo)
 
-      sender.send(dataManager, DataStoreManager.AskInfoMsg(sourceInfo.name))
+      sender.send(dataManager, DataStoreManager.AskInfoAndViews(sourceInfo.name))
       val actual = sender.receiveOne(5 second)
       actual must_== Seq(sourceInfo)
 
-      sender.send(dataManager, DataStoreManager.AskInfoMsg("nobody"))
+      sender.send(dataManager, DataStoreManager.AskInfoAndViews("nobody"))
       sender.expectMsg(Seq.empty)
     }
     "forward the query to agent" in {
@@ -96,7 +96,7 @@ class DataStoreManagerTest extends TestkitExample with SpecificationLike with Mo
       meta.receiveOne(5 seconds)
       meta.reply(initialInfo)
 
-      sender.send(dataManager, DataStoreManager.AskInfoMsg(sourceInfo.name))
+      sender.send(dataManager, DataStoreManager.AskInfoAndViews(sourceInfo.name))
       sender.expectMsg(Seq(sourceInfo))
 
       val createView = CreateView("zika", zikaCreateQuery)
@@ -104,7 +104,7 @@ class DataStoreManagerTest extends TestkitExample with SpecificationLike with Mo
       sender.expectNoMsg(500 milli)
       val upsertRecord = meta.receiveOne(5 seconds)
       upsertRecord.asInstanceOf[UpsertRecord].dataset must_== metaDataSet
-      sender.send(dataManager, DataStoreManager.AskInfoMsg(sourceInfo.name))
+      sender.send(dataManager, DataStoreManager.AskInfoAndViews(sourceInfo.name))
       val response = sender.receiveOne(2000 milli).asInstanceOf[Seq[DataSetInfo]]
       response.size must_== 2
       response.head must_== sourceInfo
@@ -135,7 +135,7 @@ class DataStoreManagerTest extends TestkitExample with SpecificationLike with Mo
 
       sender.send(dataManager, DataStoreManager.AreYouReady)
       sender.expectMsg(true)
-      sender.send(dataManager, DataStoreManager.AskInfoMsg(sourceInfo.name))
+      sender.send(dataManager, DataStoreManager.AskInfoAndViews(sourceInfo.name))
       sender.expectMsg(Seq(sourceInfo, zikaHalfYearViewInfo))
 
       val appendView = AppendView(zikaHalfYearViewInfo.name, Query(sourceInfo.name))
@@ -143,7 +143,7 @@ class DataStoreManagerTest extends TestkitExample with SpecificationLike with Mo
       child.expectMsg(appendView)
       child.reply(true)
       sender.expectNoMsg(1 seconds)
-      sender.send(dataManager, DataStoreManager.AskInfoMsg(zikaHalfYearViewInfo.name))
+      sender.send(dataManager, DataStoreManager.AskInfoAndViews(zikaHalfYearViewInfo.name))
       val newInfo = sender.receiveOne(1 second).asInstanceOf[Seq[DataSetInfo]].head
       newInfo.name must_== zikaHalfYearViewInfo.name
       newInfo.dataInterval.getEnd must_== TimeField.TimeFormat.parseDateTime((viewStatJson \\ "max").head.as[String])

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClientTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClientTest.scala
@@ -12,7 +12,7 @@ import play.api.libs.json._
 
 import scala.concurrent.ExecutionContext
 
-class ClientTest extends TestkitExample with SpecificationLike with MockConnClient {
+class RESTFulBerryClientTest extends TestkitExample with SpecificationLike with MockConnClient {
 
   implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
 
@@ -32,7 +32,7 @@ class ClientTest extends TestkitExample with SpecificationLike with MockConnClie
       val query = Query(sourceInfo.name)
       when(mockParser.parse(jsonRequest)).thenReturn(query)
 
-      val client = system.actorOf(Client.props(sender.ref, mockParser, dataManager.ref, mockPlanner, Config.Default))
+      val client = system.actorOf(RESTFulBerryClient.props(sender.ref, mockParser, dataManager.ref, mockPlanner, Config.Default))
       sender.send(client, jsonRequest)
       dataManager.expectMsg(DataStoreManager.AskInfoMsg(query.dataset))
       dataManager.reply(Seq(sourceInfo))
@@ -67,12 +67,12 @@ class ClientTest extends TestkitExample with SpecificationLike with MockConnClie
       val query = Query(sourceInfo.name)
       when(mockParser.parse(jsonRequest)).thenReturn(query)
 
-      val client = system.actorOf(Client.props(sender.ref, mockParser, dataManager.ref, mockPlanner, Config.Default))
+      val client = system.actorOf(RESTFulBerryClient.props(sender.ref, mockParser, dataManager.ref, mockPlanner, Config.Default))
       sender.send(client, jsonRequest)
       dataManager.expectMsg(DataStoreManager.AskInfoMsg(query.dataset))
       dataManager.reply(Seq.empty)
 
-      sender.expectMsg(Client.NoSuchDataset(sourceInfo.name))
+      sender.expectMsg(RESTFulBerryClient.NoSuchDataset(sourceInfo.name))
       ok
     }
   }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClientTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClientTest.scala
@@ -32,9 +32,9 @@ class RESTFulBerryClientTest extends TestkitExample with SpecificationLike with 
       val query = Query(sourceInfo.name)
       when(mockParser.parse(jsonRequest)).thenReturn(query)
 
-      val client = system.actorOf(RESTFulBerryClient.props(sender.ref, mockParser, dataManager.ref, mockPlanner, Config.Default))
+      val client = system.actorOf(RESTFulBerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default))
       sender.send(client, jsonRequest)
-      dataManager.expectMsg(DataStoreManager.AskInfoMsg(query.dataset))
+      dataManager.expectMsg(DataStoreManager.AskInfoAndViews(query.dataset))
       dataManager.reply(Seq(sourceInfo))
 
       val query1 = Query(sourceInfo.name, filter = Seq(textFilter))
@@ -67,9 +67,9 @@ class RESTFulBerryClientTest extends TestkitExample with SpecificationLike with 
       val query = Query(sourceInfo.name)
       when(mockParser.parse(jsonRequest)).thenReturn(query)
 
-      val client = system.actorOf(RESTFulBerryClient.props(sender.ref, mockParser, dataManager.ref, mockPlanner, Config.Default))
+      val client = system.actorOf(RESTFulBerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default))
       sender.send(client, jsonRequest)
-      dataManager.expectMsg(DataStoreManager.AskInfoMsg(query.dataset))
+      dataManager.expectMsg(DataStoreManager.AskInfoAndViews(query.dataset))
       dataManager.reply(Seq.empty)
 
       sender.expectMsg(RESTFulBerryClient.NoSuchDataset(sourceInfo.name))

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -21,6 +21,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
   import org.mockito.Mockito._
 
   import scala.concurrent.duration._
+  import ReactiveBerryClient.NoTransform
 
   DateTimeZone.setDefault(DateTimeZone.UTC)
   val startTime = new DateTime(2016, 1, 1, 0, 0)
@@ -128,7 +129,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       val client = system.actorOf(ReactiveBerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default, childMaker, responseTime))
 
       val query = mockParser.parse(hourCountJSON)
-      sender.send(client, ReactiveBerryClient.Request(hourCountJSON, (js: JsArray) => js))
+      sender.send(client, ReactiveBerryClient.Request(Seq((hourCountJSON, NoTransform))))
       val askInfo = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
       askInfo.who must_== query.dataset
 
@@ -139,7 +140,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       val slicedQ1 = worker.receiveOne(5 seconds).asInstanceOf[Query]
       val interval1 = slicedQ1.getTimeInterval("create_at").get
       interval1.getEnd must_== endTime
-      interval1.toDurationMillis must_== (Config.Default.FirstQueryTimeGap).toMillis
+      interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       worker.reply(getRet(1))
       sender.expectMsg(getRet(1))
@@ -178,7 +179,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
 
       val query = mockParser.parse(hourCountJSON)
 
-      sender.send(client, ReactiveBerryClient.Request(hourCountJSON, (js: JsArray) => js))
+      sender.send(client, ReactiveBerryClient.Request(Seq((hourCountJSON, NoTransform))))
       val askInfo = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
       askInfo.who must_== query.dataset
       dataManager.reply(Some(TestQuery.sourceInfo))
@@ -200,7 +201,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval2.getStartMillis must be_>=(startTime.getMillis)
 
       //send a new request
-      sender.send(client, ReactiveBerryClient.Request(hourCountJSON2, (js: JsArray) => js))
+      sender.send(client, ReactiveBerryClient.Request(Seq((hourCountJSON2, NoTransform))))
       Thread.sleep(250)
       worker.reply(getRet(2))
 
@@ -233,12 +234,12 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
 
       val query = mockParser.parse(hourCountJSON)
 
-      sender.send(client, ReactiveBerryClient.Request(hourCountJSON, (js: JsArray) => js))
+      sender.send(client, ReactiveBerryClient.Request(Seq((hourCountJSON, NoTransform))))
       val askInfo = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
       askInfo.who must_== query.dataset
 
       //new query comes before the worker even started
-      sender.send(client, ReactiveBerryClient.Request(hourCountJSON2, (js: JsArray) => js))
+      sender.send(client, ReactiveBerryClient.Request(Seq((hourCountJSON2, NoTransform))))
 
       dataManager.reply(Some(TestQuery.sourceInfo))
 

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -4,16 +4,13 @@ import java.util.concurrent.Executors
 
 import akka.actor.{ActorRef, ActorRefFactory}
 import akka.testkit.TestProbe
-import edu.uci.ics.cloudberry.zion.TInterval
 import edu.uci.ics.cloudberry.zion.common.Config
-import edu.uci.ics.cloudberry.zion.model.impl.{DataSetInfo, JSONParser, QueryPlanner, TestQuery}
-import edu.uci.ics.cloudberry.zion.model.schema.{CreateView, Query, TimeField}
-import edu.uci.ics.cloudberry.zion.model.util.MockConnClient
+import edu.uci.ics.cloudberry.zion.model.impl.{JSONParser, QueryPlanner, TestQuery}
+import edu.uci.ics.cloudberry.zion.model.schema.{Query, TimeField}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.SpecificationLike
 import play.api.libs.json._
-import org.specs2.mutable.Specification
 
 import scala.concurrent.ExecutionContext
 
@@ -21,8 +18,9 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
 
   implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
 
-  import scala.concurrent.duration._
   import org.mockito.Mockito._
+
+  import scala.concurrent.duration._
 
   DateTimeZone.setDefault(DateTimeZone.UTC)
   val startTime = new DateTime(2016, 1, 1, 0, 0)
@@ -84,7 +82,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       val client = system.actorOf(ReactiveBerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default, childMaker, responseTime))
 
       val query = mockParser.parse(hourCountJSON)
-      sender.send(client, hourCountJSON)
+      sender.send(client, ReactiveBerryClient.Request(hourCountJSON, (js: JsArray) => js))
       val askInfo = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
       askInfo.who must_== query.dataset
 

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -109,7 +109,6 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
        |  }
        |}
     """.stripMargin)
-  println("114")
 
   sequential
 
@@ -140,7 +139,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       val slicedQ1 = worker.receiveOne(5 seconds).asInstanceOf[Query]
       val interval1 = slicedQ1.getTimeInterval("create_at").get
       interval1.getEnd must_== endTime
-      interval1.toDurationMillis must_== (30 days).toMillis
+      interval1.toDurationMillis must_== (Config.Default.FirstQueryTimeGap).toMillis
 
       worker.reply(getRet(1))
       sender.expectMsg(getRet(1))
@@ -189,7 +188,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       val slicedQ1 = worker.receiveOne(5 seconds).asInstanceOf[Query]
       val interval1 = slicedQ1.getTimeInterval("create_at").get
       interval1.getEnd must_== endTime
-      interval1.toDurationMillis must_== (30 days).toMillis
+      interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       worker.reply(getRet(1))
       sender.expectMsg(getRet(1))
@@ -213,7 +212,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       val slicedQ11 = worker.receiveOne(5 seconds).asInstanceOf[Query]
       val interval11 = slicedQ11.getTimeInterval("create_at").get
       interval11.getEnd must_== endTime2
-      interval11.toDurationMillis must_== (30 days).toMillis
+      interval11.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       worker.reply(getRet(1))
       sender.expectMsg(getRet(1))
@@ -255,7 +254,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       val slicedQ1 = worker.receiveOne(5 seconds).asInstanceOf[Query]
       val interval1 = slicedQ1.getTimeInterval("create_at").get
       interval1.getEnd must_== endTime2
-      interval1.toDurationMillis must_== (30 days).toMillis
+      interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       worker.reply(getRet(1))
       sender.expectMsg(getRet(1))

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -64,6 +64,53 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
        |}
     """.stripMargin)
 
+  val endTime2 = new DateTime(2016, 11, 30, 0, 0)
+  val hourCountJSON2 = Json.parse(
+    s"""
+       |{
+       |  "dataset": "twitter.ds_tweet",
+       |  "filter": [
+       |  {
+       |    "field": "create_at",
+       |    "relation": "inRange",
+       |    "values": [
+       |      "${TimeField.TimeFormat.print(startTime)}",
+       |      "${TimeField.TimeFormat.print(endTime2)}"
+       |    ]
+       |  },
+       |  {
+       |    "field": "geo_tag.stateID",
+       |    "relation": "in",
+       |    "values": [42]
+       |  }
+       |  ],
+       |  "group": {
+       |    "by": [
+       |      {
+       |        "field": "create_at",
+       |        "apply": {
+       |          "name": "interval",
+       |          "args" : {
+       |            "unit": "hour"
+       |          }
+       |        },
+       |        "as": "hour"
+       |      }
+       |    ],
+       |    "aggregate": [
+       |      {
+       |        "field": "*",
+       |        "apply": {
+       |          "name" : "count"
+       |        },
+       |        "as": "count"
+       |      }
+       |    ]
+       |  }
+       |}
+    """.stripMargin)
+  println("114")
+
   sequential
 
   "Client" should {
@@ -118,9 +165,101 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       ok
     }
     "cancel the haven't finished query if newer query comes" in {
+      val sender = new TestProbe(system)
+      val dataManager = new TestProbe(system)
+      val worker = new TestProbe(system)
+      val mockParser = new JSONParser
+      val mockPlanner = mock[QueryPlanner]
+      when(mockPlanner.calculateMergeFunc(any, any)).thenReturn(QueryPlanner.Unioner)
+      val responseTime = 50
+
+      def childMaker(context: ActorRefFactory, client: ReactiveBerryClient): ActorRef = worker.ref
+
+      val client = system.actorOf(ReactiveBerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default, childMaker, responseTime))
+
+      val query = mockParser.parse(hourCountJSON)
+
+      sender.send(client, ReactiveBerryClient.Request(hourCountJSON, (js: JsArray) => js))
+      val askInfo = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
+      askInfo.who must_== query.dataset
+      dataManager.reply(Some(TestQuery.sourceInfo))
+
+      def getRet(i: Int) = JsArray(Seq(JsObject(Seq("hour" -> JsNumber(i), "count" -> JsNumber(i)))))
+
+      val slicedQ1 = worker.receiveOne(5 seconds).asInstanceOf[Query]
+      val interval1 = slicedQ1.getTimeInterval("create_at").get
+      interval1.getEnd must_== endTime
+      interval1.toDurationMillis must_== (30 days).toMillis
+
+      worker.reply(getRet(1))
+      sender.expectMsg(getRet(1))
+
+      val slicedQ2 = worker.receiveOne(5 seconds).asInstanceOf[Query]
+      val interval2 = slicedQ2.getTimeInterval("create_at").get
+      println(interval2)
+      interval2.getEnd must_== interval1.getStart
+      interval2.getStartMillis must be_>=(startTime.getMillis)
+
+      //send a new request
+      sender.send(client, ReactiveBerryClient.Request(hourCountJSON2, (js: JsArray) => js))
+      Thread.sleep(250)
+      worker.reply(getRet(2))
+
+      sender.expectNoMsg()
+      val askInfo2 = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
+      askInfo2.who must_== (hourCountJSON2 \ "dataset").as[String]
+      dataManager.reply(Some(TestQuery.sourceInfo))
+
+      val slicedQ11 = worker.receiveOne(5 seconds).asInstanceOf[Query]
+      val interval11 = slicedQ11.getTimeInterval("create_at").get
+      interval11.getEnd must_== endTime2
+      interval11.toDurationMillis must_== (30 days).toMillis
+
+      worker.reply(getRet(1))
+      sender.expectMsg(getRet(1))
       ok
     }
     "don't even start slice if the request is updated before info response gets back" in {
+      val sender = new TestProbe(system)
+      val dataManager = new TestProbe(system)
+      val worker = new TestProbe(system)
+      val mockParser = new JSONParser
+      val mockPlanner = mock[QueryPlanner]
+      when(mockPlanner.calculateMergeFunc(any, any)).thenReturn(QueryPlanner.Unioner)
+      val responseTime = 50
+
+      def childMaker(context: ActorRefFactory, client: ReactiveBerryClient): ActorRef = worker.ref
+
+      val client = system.actorOf(ReactiveBerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default, childMaker, responseTime))
+
+      val query = mockParser.parse(hourCountJSON)
+
+      sender.send(client, ReactiveBerryClient.Request(hourCountJSON, (js: JsArray) => js))
+      val askInfo = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
+      askInfo.who must_== query.dataset
+
+      //new query comes before the worker even started
+      sender.send(client, ReactiveBerryClient.Request(hourCountJSON2, (js: JsArray) => js))
+
+      dataManager.reply(Some(TestQuery.sourceInfo))
+
+      worker.expectNoMsg(1 seconds)
+      sender.expectNoMsg(1 seconds)
+
+      val askInfo2 = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
+      askInfo2.who must_== (hourCountJSON2 \ "dataset").as[String]
+      dataManager.reply(Some(TestQuery.sourceInfo))
+
+      def getRet(i: Int) = JsArray(Seq(JsObject(Seq("hour" -> JsNumber(i), "count" -> JsNumber(i)))))
+
+      val slicedQ1 = worker.receiveOne(5 seconds).asInstanceOf[Query]
+      val interval1 = slicedQ1.getTimeInterval("create_at").get
+      interval1.getEnd must_== endTime2
+      interval1.toDurationMillis must_== (30 days).toMillis
+
+      worker.reply(getRet(1))
+      sender.expectMsg(getRet(1))
+
       ok
     }
   }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -1,0 +1,120 @@
+package edu.uci.ics.cloudberry.zion.actor
+
+import java.util.concurrent.Executors
+
+import akka.actor.{ActorRef, ActorRefFactory}
+import akka.testkit.TestProbe
+import edu.uci.ics.cloudberry.zion.TInterval
+import edu.uci.ics.cloudberry.zion.common.Config
+import edu.uci.ics.cloudberry.zion.model.impl.{DataSetInfo, JSONParser, QueryPlanner, TestQuery}
+import edu.uci.ics.cloudberry.zion.model.schema.{CreateView, Query, TimeField}
+import edu.uci.ics.cloudberry.zion.model.util.MockConnClient
+import org.joda.time.{DateTime, DateTimeZone}
+import org.specs2.mock.Mockito
+import org.specs2.mutable.SpecificationLike
+import play.api.libs.json._
+import org.specs2.mutable.Specification
+
+import scala.concurrent.ExecutionContext
+
+class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with Mockito {
+
+  implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
+
+  import scala.concurrent.duration._
+  import org.mockito.Mockito._
+
+  DateTimeZone.setDefault(DateTimeZone.UTC)
+  val startTime = new DateTime(2016, 1, 1, 0, 0)
+  val endTime = new DateTime(2016, 12, 31, 0, 0)
+  val hourCountJSON = Json.parse(
+    s"""
+       |{
+       |  "dataset": "twitter.ds_tweet",
+       |  "filter": [
+       |  {
+       |    "field": "create_at",
+       |    "relation": "inRange",
+       |    "values": [
+       |      "${TimeField.TimeFormat.print(startTime)}",
+       |      "${TimeField.TimeFormat.print(endTime)}"
+       |    ]
+       |  }],
+       |  "group": {
+       |    "by": [
+       |      {
+       |        "field": "create_at",
+       |        "apply": {
+       |          "name": "interval",
+       |          "args" : {
+       |            "unit": "hour"
+       |          }
+       |        },
+       |        "as": "hour"
+       |      }
+       |    ],
+       |    "aggregate": [
+       |      {
+       |        "field": "*",
+       |        "apply": {
+       |          "name" : "count"
+       |        },
+       |        "as": "count"
+       |      }
+       |    ]
+       |  }
+       |}
+    """.stripMargin)
+
+  sequential
+
+  "Client" should {
+    "slice the query into small pieces and return the merged result incrementally" in {
+
+      val sender = new TestProbe(system)
+      val dataManager = new TestProbe(system)
+      val worker = new TestProbe(system)
+      val mockParser = new JSONParser
+      val mockPlanner = mock[QueryPlanner]
+      when(mockPlanner.calculateMergeFunc(any, any)).thenReturn(QueryPlanner.Unioner)
+      val responseTime = 1000
+
+      def childMaker(context: ActorRefFactory, client: ReactiveBerryClient): ActorRef = worker.ref
+
+      val client = system.actorOf(ReactiveBerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default, childMaker, responseTime))
+
+      val query = mockParser.parse(hourCountJSON)
+      sender.send(client, hourCountJSON)
+      val askInfo = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
+      askInfo.who must_== query.dataset
+
+      dataManager.reply(Some(TestQuery.sourceInfo))
+
+      def getRet(i: Int) = JsArray(Seq(JsObject(Seq("hour" -> JsNumber(i), "count" -> JsNumber(i)))))
+
+      val slicedQ1 = worker.receiveOne(5 seconds).asInstanceOf[Query]
+      val interval1 = slicedQ1.getTimeInterval("create_at").get
+      interval1.getEnd must_== endTime
+      interval1.toDurationMillis must_== (30 days).toMillis
+
+      worker.reply(getRet(1))
+      sender.expectMsg(getRet(1))
+
+      val slicedQ2 = worker.receiveOne(5 seconds).asInstanceOf[Query]
+      val interval2 = slicedQ2.getTimeInterval("create_at").get
+      println(interval2)
+      interval2.getEnd must_== interval1.getStart
+      interval2.getStartMillis must be_>=(startTime.getMillis)
+
+      worker.reply(getRet(2))
+      sender.expectMsg(getRet(1) ++ getRet(2))
+      ok
+    }
+    "cancel the haven't finished query if newer query comes" in {
+      ok
+    }
+    "don't even start slice if the request is updated before info response gets back" in {
+      ok
+    }
+  }
+}

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -77,7 +77,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       val mockParser = new JSONParser
       val mockPlanner = mock[QueryPlanner]
       when(mockPlanner.calculateMergeFunc(any, any)).thenReturn(QueryPlanner.Unioner)
-      val responseTime = 1000
+      val responseTime = 50
 
       def childMaker(context: ActorRefFactory, client: ReactiveBerryClient): ActorRef = worker.ref
 
@@ -108,6 +108,15 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
 
       worker.reply(getRet(2))
       sender.expectMsg(getRet(1) ++ getRet(2))
+
+      val slicedQ3 = worker.receiveOne(5 seconds).asInstanceOf[Query]
+      val interval3 = slicedQ3.getTimeInterval("create_at").get
+      println(interval3)
+      interval3.getEnd must_== interval2.getStart
+      interval3.getStartMillis must be_>=(startTime.getMillis)
+
+      worker.reply(getRet(3))
+      sender.expectMsg(getRet(1) ++ getRet(2) ++ getRet(3))
       ok
     }
     "cancel the haven't finished query if newer query comes" in {

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGeneratorTest.scala
@@ -9,7 +9,7 @@ class AQLGeneratorTest extends Specification {
 
   val parser = new AQLGenerator
 
-  "AQLQueryParser parseQuery" should {
+  "AQLGenerate generate" should {
     "translate a simple filter by time and group by time query" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrCount))
@@ -575,7 +575,7 @@ class AQLGeneratorTest extends Specification {
           |  hashtags : {{string}}?
           |}
           |drop dataset zika if exists;
-          |create dataset zika(twitter.typeTweet) primary key id
+          |create dataset zika(twitter.typeTweet) primary key id with filter on 'create_at'
           |insert into dataset zika (
           |for $t in dataset twitter.ds_tweet
           |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0


### PR DESCRIPTION
This PR slices a group of queries into groups of queries that shared the same time intervals, which enables a reactive response.

#181 