### PR TITLE
set the min gap between the consecutive queries by config file

### DIFF
--- a/neo/conf/application.conf
+++ b/neo/conf/application.conf
@@ -86,6 +86,7 @@ view.update.interval = "30 minutes"
 view.meta.flush.interval = "30 minutes"
 
 berry.firstquery.gap = "2 days"
+berry.query.gap = "1 day"
 
 asterixdb.url = "http://kiwi.ics.uci.edu:19002/aql"
 asterixdb.view.meta.name = "viewMeta"

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClient.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClient.scala
@@ -137,7 +137,7 @@ class ReactiveBerryClient(val jsonParser: JSONParser,
   }
 
   private def calculateNext(interval: TInterval, timeSpend: Long, boundary: TInterval): TInterval = {
-    val newDuration = (interval.toDurationMillis * responseTime / timeSpend.toDouble).toLong
+    val newDuration = Math.max(config.MinTimeGap.toMillis, (interval.toDurationMillis * responseTime / timeSpend.toDouble).toLong)
     val startTime = Math.max(boundary.getStartMillis, interval.getStartMillis - newDuration)
     new TInterval(startTime, interval.getStartMillis)
   }

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/common/Config.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/common/Config.scala
@@ -22,6 +22,7 @@ class Config(config: Configuration) {
 
   val FirstQueryTimeGap = config.getString("berry.firstquery.gap").map(parseTimePair).getOrElse(2 days)
 
+  val MinTimeGap = config.getString("berry.query.gap").map(parseTimePair).getOrElse(1 day)
 }
 
 object Config {


### PR DESCRIPTION
... To avoid the time slice is too small which won't have any benefits since it has to scan the component again and again. 

The ideal solution should parse the minimal group level by queries.