### PR TITLE
fix the lt function in queryPlanner to merge the result

### DIFF
--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlanner.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlanner.scala
@@ -242,10 +242,12 @@ object QueryPlanner {
     //ref http://stackoverflow.com/q/39152687/2598198
     def lt[A <: JsValue : Ordering](left: A, right: A, order: SortOrder.Value): Boolean = {
       import Ordering.Implicits._
-      if (left <= right) {
+      if (left < right) {
         order == SortOrder.ASC
-      } else {
+      } else if (left > right) {
         order == SortOrder.DSC
+      } else {
+        false
       }
     }
 
@@ -267,7 +269,7 @@ object QueryPlanner {
           case _ => ???
         }
       }
-      true
+      false // equal
     }
     JsArray(mergedArray.value.sortWith(ltObj))
   }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlannerTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlannerTest.scala
@@ -140,31 +140,31 @@ class QueryPlannerTest extends Specification {
           |  "count" : 600
           |}, {
           |  "day" : "d5",
-          |  "state" : 15,
-          |  "count" : 500
-          |}, {
-          |  "day" : "d5",
           |  "state" : 5,
           |  "count" : 500
           |}, {
-          |  "day" : "d4",
-          |  "state" : 14,
-          |  "count" : 400
+          |  "day" : "d5",
+          |  "state" : 15,
+          |  "count" : 500
           |}, {
           |  "day" : "d4",
           |  "state" : 4,
           |  "count" : 400
           |}, {
-          |  "day" : "d3",
-          |  "state" : 13,
-          |  "count" : 300
+          |  "day" : "d4",
+          |  "state" : 14,
+          |  "count" : 400
           |}, {
           |  "day" : "d3",
           |  "state" : 3,
           |  "count" : 300
           |}, {
+          |  "day" : "d3",
+          |  "state" : 13,
+          |  "count" : 300
+          |}, {
           |  "day" : "d2",
-          |  "state" : 12,
+          |  "state" : 2,
           |  "count" : 200
           |}]
         """.stripMargin)


### PR DESCRIPTION
Fix the `lessThan` function that required by the `QueryPlanner::Merger`. 
It needs to produce a consistent order. Otherwise, an exception will be thrown as below:
```Comparison method violates its general contract!``` 

ref : http://stackoverflow.com/a/8327575/2598198