### PR TITLE
Make the suggestView behavior optional

### DIFF
--- a/neo/app/controllers/Application.scala
+++ b/neo/app/controllers/Application.scala
@@ -39,7 +39,7 @@ class Application @Inject()(val wsClient: WSClient,
 
   val manager = system.actorOf(DataStoreManager.props(Migration_20160814.berryMeta, asterixConn, AQLGenerator, config))
 
-  val berryProp = RESTFulBerryClient.props(new JSONParser(), manager, new QueryPlanner(), config)
+  val berryProp = RESTFulBerryClient.props(new JSONParser(), manager, new QueryPlanner(), suggestView = true, config)
   val berryClient = system.actorOf(berryProp)
   val neoActor = system.actorOf(NeoActor.props(berryProp))
 

--- a/neo/public/javascripts/common/services.js
+++ b/neo/public/javascripts/common/services.js
@@ -42,7 +42,6 @@ angular.module('cloudberry.common', [])
     ws.onmessage = function(event) {
       $timeout(function() {
         var result = JSONbig.parse(event.data);
-        console.log(result);
         switch (result.key) {
           case "byPlace":
             asterixService.mapResult = result.value;

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClient.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClient.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param config      the configuration
   * @param ec          implicit executionContext
   */
-class RESTFulBerryClient(val jsonParser: JSONParser, val dataManager: ActorRef, val planner: QueryPlanner, val config: Config)
+class RESTFulBerryClient(val jsonParser: JSONParser, val dataManager: ActorRef, val planner: QueryPlanner, suggestView: Boolean, val config: Config)
                         (implicit val ec: ExecutionContext) extends Actor with ActorLogging {
 
   import RESTFulBerryClient._
@@ -50,8 +50,10 @@ class RESTFulBerryClient(val jsonParser: JSONParser, val dataManager: ActorRef, 
           output ! r
         }
 
-        val newViews = planner.suggestNewView(query, infos.head, infos.tail)
-        newViews.foreach(dataManager ! _)
+        if (suggestView) {
+          val newViews = planner.suggestNewView(query, infos.head, infos.tail)
+          newViews.foreach(dataManager ! _)
+        }
     }
   }
 
@@ -66,9 +68,9 @@ class RESTFulBerryClient(val jsonParser: JSONParser, val dataManager: ActorRef, 
 
 object RESTFulBerryClient {
 
-  def props(jsonParser: JSONParser, dataManagerRef: ActorRef, planner: QueryPlanner, config: Config)
+  def props(jsonParser: JSONParser, dataManagerRef: ActorRef, planner: QueryPlanner, suggestView: Boolean, config: Config)
            (implicit ec: ExecutionContext) = {
-    Props(new RESTFulBerryClient(jsonParser, dataManagerRef, planner, config))
+    Props(new RESTFulBerryClient(jsonParser, dataManagerRef, planner, suggestView, config))
   }
 
   case class NoSuchDataset(name: String)

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClientTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/RESTFulBerryClientTest.scala
@@ -32,7 +32,7 @@ class RESTFulBerryClientTest extends TestkitExample with SpecificationLike with 
       val query = Query(sourceInfo.name)
       when(mockParser.parse(jsonRequest)).thenReturn(query)
 
-      val client = system.actorOf(RESTFulBerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default))
+      val client = system.actorOf(RESTFulBerryClient.props(mockParser, dataManager.ref, mockPlanner, suggestView = true, Config.Default))
       sender.send(client, jsonRequest)
       dataManager.expectMsg(DataStoreManager.AskInfoAndViews(query.dataset))
       dataManager.reply(Seq(sourceInfo))
@@ -67,7 +67,7 @@ class RESTFulBerryClientTest extends TestkitExample with SpecificationLike with 
       val query = Query(sourceInfo.name)
       when(mockParser.parse(jsonRequest)).thenReturn(query)
 
-      val client = system.actorOf(RESTFulBerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default))
+      val client = system.actorOf(RESTFulBerryClient.props(mockParser, dataManager.ref, mockPlanner, suggestView = true, Config.Default))
       sender.send(client, jsonRequest)
       dataManager.expectMsg(DataStoreManager.AskInfoAndViews(query.dataset))
       dataManager.reply(Seq.empty)


### PR DESCRIPTION
In RESTFulClient, we suggest the view at the end of each query. It is still too early for the Reactive Client because there is still a queue of queries to ask. It will be less contention if we suggest the view creation to the end of the last query.