### PR TITLE
Disable the stdout output in FileFeed

### DIFF
--- a/noah/src/main/scala/edu/uci/ics/cloudberry/noah/feed/FeedSocketAdapterClient.java
+++ b/noah/src/main/scala/edu/uci/ics/cloudberry/noah/feed/FeedSocketAdapterClient.java
@@ -43,7 +43,7 @@ public class FeedSocketAdapterClient {
 
     public void ingest(String record) throws IOException{
         recordCount++;
-        System.out.println("send record: " + recordCount);
+        System.err.println("send record: " + recordCount);
         byte[] b = record.replaceAll("\\s+", " ").getBytes();
         try {
             out.write(b);

--- a/noah/src/main/scala/edu/uci/ics/cloudberry/noah/feed/FileFeedDriver.java
+++ b/noah/src/main/scala/edu/uci/ics/cloudberry/noah/feed/FileFeedDriver.java
@@ -68,7 +68,6 @@ public class FileFeedDriver {
             br = new BufferedReader(reader);
             String nextRecord;
             while ((nextRecord = br.readLine()) != null) {
-                System.out.println(nextRecord);
                 client.ingest(nextRecord);
             }
         } catch (CmdLineException e) {


### PR DESCRIPTION
A simple fix to remove the println to stdout.