### PR TITLE
Fix front end mem issue

### DIFF
--- a/neo/public/stylesheets/main.css
+++ b/neo/public/stylesheets/main.css
@@ -101,7 +101,7 @@ search-bar {
 }
 
 #logo_img{
-  z-index = 0;
+  z-index: 0;
   position: absolute;
   top:2%;
   left:10%;


### PR DESCRIPTION
the front-end has the memory issue for a long time. by using the chrome profiling tool, a large number of allocated objects are from the time-serial dc plugin. by comparing the [example](https://dc-js.github.io/dc.js/docs/stock.html) about `redrawAll`, we can notice that we call `renderAll` each time. By changing it to `redrawAll`, the frontend memory issue is solved. 

issue: #204 