### PR TITLE
Enable the [WARN] and [ERROR] console log messages

### DIFF
--- a/neo/conf/logback.xml
+++ b/neo/conf/logback.xml
@@ -12,6 +12,8 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter class="ch.qos.logback.classic.filter.LevelFilter">
       <level>INFO</level>
+      <level>WARN</level>
+      <level>ERROR</level>
       <onMatch>ACCEPT</onMatch>
       <onMismatch>DENY</onMismatch>
     </filter>


### PR DESCRIPTION
warn and error logging messages are added in the filter of configuration file logback.xml. They could be very useful in debugging/testing in Play! framework.