### PR TITLE
[Update] hide current count when the page loads

### DIFF
--- a/neo/public/javascripts/timeseries/controllers.js
+++ b/neo/public/javascripts/timeseries/controllers.js
@@ -9,6 +9,7 @@ angular.module('cloudberry.timeseries', ['cloudberry.common'])
     $scope.empty = [];
     $scope.totalCount = 0;
     $scope.currentTweetCount = 0;
+    $scope.queried = false;
     for (var date = new Date(); date >= Asterix.startDate; date.setDate(date.getDate()-1)) {
       $scope.empty.push({'time': new Date(date), 'count': 0});
     }
@@ -34,7 +35,7 @@ angular.module('cloudberry.timeseries', ['cloudberry.common'])
     countDiv.id = "count-div";
     countDiv.title = "Display the count information of Tweets";
     countDiv.innerHTML = [
-      "<p id='count'>{{ currentTweetCount | number:0 }}<span id='count-text'>&nbsp;&nbsp;of&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></p>",
+      "<div ng-if='queried'><p id='count'>{{ currentTweetCount | number:0 }}<span id='count-text'>&nbsp;&nbsp;of&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></p></div>",
       "<p id='count'>{{ totalCount | number:0 }}<span id='count-text'>&nbsp;&nbsp;tweets</span></p>",
     ].join("");
     var stats = document.getElementsByClassName("stats")[0];
@@ -93,7 +94,8 @@ angular.module('cloudberry.timeseries', ['cloudberry.common'])
                 if(newVal.length == 0)
                   return;
             }
-
+            
+            $scope.queried = true;
             var ndx = $scope.ndx;
             if (ndx) {
               ndx.remove();

--- a/neo/public/stylesheets/main.css
+++ b/neo/public/stylesheets/main.css
@@ -119,7 +119,6 @@ search-bar {
 
 .stats{
   position: absolute;
-
   bottom:0;
   pointer-events: none;
   line-height: 1;


### PR DESCRIPTION
Update to my previous PR #257 

Purpose:
- Get rid of "0 of" when we first load the page, then show the real number of tweets in the results after a user submits a query.

Implementation details:
- use ng-if to show divs whenever we want to show them

![c1 mov](https://cloud.githubusercontent.com/assets/12385178/23638552/2a7c5522-0297-11e7-82e0-47ebc683000b.gif)
