### PR TITLE
[Hotfix] Prevent Timeline from Overlapping the Sidebar

### DIFF
--- a/neo/public/javascripts/timeseries/controllers.js
+++ b/neo/public/javascripts/timeseries/controllers.js
@@ -80,7 +80,7 @@ angular.module('cloudberry.timeseries', ['cloudberry.common'])
       left: 40
     };
     // set the initial width of the timeline equal to the initial width of the browser window
-    var width = $(window).width() * 0.8 - margin.left - margin.right;
+    var width = $(window).width() * 0.6 - margin.left - margin.right;
     var height = 150 - margin.top - margin.bottom;
       return {
         restrict: "E",


### PR DESCRIPTION
Purpose:
- Prevent the timeline from overlapping with the sidebar

Implementation details:
- Reduce timeline width 

Screenshots:
# 720p
![screen shot 2017-03-07 at 20 56 11](https://cloud.githubusercontent.com/assets/12385178/23690829/7a9e5a4a-0379-11e7-91c2-debf951be3e1.jpg)
![screen shot 2017-03-07 at 20 56 19](https://cloud.githubusercontent.com/assets/12385178/23690836/7cdc145a-0379-11e7-9306-2ca9e9460a1f.jpg)
# Tablet resolution
![screen shot 2017-03-07 at 20 59 11](https://cloud.githubusercontent.com/assets/12385178/23690869/ad136a56-0379-11e7-9b37-d697f1393b20.jpg)

The timeline doesn't overlap with the sidebar under this small resolution but other elements on the page appear to be out of place. If we plan to make the Tweeter Demo compatible with small screen sizes like tablets and phones in the future, we will need to fix these out-of-place elements.