### PR TITLE
Update DataSetInfo to fix MetaSchema

### DIFF
--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/DataSetInfo.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/DataSetInfo.scala
@@ -24,7 +24,8 @@ object DataSetInfo {
 
   val MetaDataDBName: String = "berry.meta"
   val MetaSchema: Schema = Schema("berry.MetaType",
-    Seq(StringField("name")),
+    Seq(StringField("name"),
+        TimeField("stats.createTime")),
     Seq.empty,
     Seq(StringField("name")),
     TimeField("stats.createTime"))

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGeneratorTest.scala
@@ -649,6 +649,24 @@ class AQLGeneratorTest extends Specification {
       ok
     }
 
+    "translate a meta query" in {
+      val select = Some(SelectStatement(Seq(DataSetInfo.MetaSchema.timeField), Seq(SortOrder.ASC), Int.MaxValue, 0, Seq.empty))
+      val query = new Query(DataSetInfo.MetaDataDBName, select = select)
+      val result = parser.generate(query, Map(DataSetInfo.MetaDataDBName->DataSetInfo.MetaSchema))
+      removeEmptyLine(result) must_== unifyNewLine(
+        """
+          |for $t in dataset berry.meta
+          |order by $t.'stats'.'createTime' 
+          |limit 2147483647
+          |offset 0
+          |return
+          |$t
+        """.stripMargin.trim
+      )
+    }
+
+
+
   }
 
   "AQLQueryParser calcResultSchema" should {


### PR DESCRIPTION
The MetaSchema was wrong in that the timeField ("stats.createTime") was not added into its dimension fields. Now it's fixed.