### PR TITLE
[issue#293] Integration Test of SQLPPGenerator

### DIFF
--- a/neo/app/controllers/Application.scala
+++ b/neo/app/controllers/Application.scala
@@ -12,8 +12,7 @@ import db.Migration_20160814
 import edu.uci.ics.cloudberry.zion.actor.{BerryClient, DataStoreManager}
 import edu.uci.ics.cloudberry.zion.common.Config
 import edu.uci.ics.cloudberry.zion.model.datastore.AsterixConn
-import edu.uci.ics.cloudberry.zion.model.impl.{AQLGenerator, JSONParser, QueryPlanner}
-import org.joda.time.DateTime
+import edu.uci.ics.cloudberry.zion.model.impl.{JSONParser, QueryPlanner, SQLPPGenerator}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{JsValue, Json, _}
 import play.api.libs.streams.ActorFlow
@@ -39,7 +38,7 @@ class Application @Inject()(val wsClient: WSClient,
 
   Await.result(Migration_20160814.migration.up(asterixConn), 10.seconds)
 
-  val manager = system.actorOf(DataStoreManager.props(Migration_20160814.berryMeta, asterixConn, AQLGenerator, config))
+  val manager = system.actorOf(DataStoreManager.props(Migration_20160814.berryMeta, asterixConn, SQLPPGenerator, config))
 
   Logger.info("I'm initializing")
 
@@ -59,7 +58,7 @@ class Application @Inject()(val wsClient: WSClient,
   }
 
   def ws = WebSocket.accept[JsValue, JsValue] { request =>
-    ActorFlow.actorRef{ out =>
+    ActorFlow.actorRef { out =>
       RequestRouter.props(BerryClient.props(new JSONParser(), manager, new QueryPlanner(), config, out), config)
     }
   }

--- a/neo/app/db/Migration_20160814.scala
+++ b/neo/app/db/Migration_20160814.scala
@@ -27,7 +27,7 @@ private[db] class Migration_20160814() {
          |
          |create dataset $berryMeta(berry.metaType) if not exists primary key name;
          |
-         |upsert into dataset $berryMeta (
+         |upsert into $berryMeta (
          |  ${Json.toJson(DataSetInfo.write(twitterInfo))}
          |)
        """.stripMargin

--- a/neo/conf/application.conf
+++ b/neo/conf/application.conf
@@ -87,10 +87,10 @@ berry.firstquery.gap = "2 days"
 berry.query.gap = "1 day"
 
 #asterixdb.url = "http://uranium.ics.uci.edu:19002/aql"
-asterixdb.url = "http://localhost:19002/aql"
+asterixdb.url = "http://localhost:19002/query/service"
 
 # for the debug purpose, we can load a smaller json to speed up the front-end
-us.city.path="/public/data/city.sample.json"
+us.city.path = "/public/data/city.sample.json"
 
 asterixdb.view.meta.name = "viewMeta"
 tweet.url = "http://twitter-search-proxy.herokuapp.com/search/tweets?q=%s"

--- a/neo/conf/production.conf
+++ b/neo/conf/production.conf
@@ -76,7 +76,7 @@ bounded-mailbox {
 }
 
 
-asterixdb.url = "http://actinium.ics.uci.edu:19002/aql"
+asterixdb.url = "http://actinium.ics.uci.edu:19002/query/service"
 us.city.path="/public/data/city.json"
 asterixdb.view.meta.name = "viewMeta"
 tweet.url = "http://twitter-search-proxy.herokuapp.com/search/tweets?q=%s"

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/datastore/IDataConn.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/datastore/IDataConn.scala
@@ -27,7 +27,7 @@ class AsterixConn(url: String, wSClient: WSClient)(implicit ec: ExecutionContext
 
   def postQuery(query: String): Future[JsValue] = {
     postWithCheckingStatus(query, (ws: WSResponse) => {
-      ws.json.asInstanceOf[JsObject].value.get("results").get
+      ws.json.asInstanceOf[JsObject].value("results")
     }, (ws: WSResponse) => defaultQueryResponse)
   }
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/datastore/IDataConn.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/datastore/IDataConn.scala
@@ -48,14 +48,19 @@ class AsterixConn(url: String, wSClient: WSClient)(implicit ec: ExecutionContext
   }
 
   def post(query: String): Future[WSResponse] = {
-    val f = wSClient.url(url).withRequestTimeout(Duration.Inf).post(Map("statement" -> Seq(query), "mode" -> Seq("synchronous"), "include-results" -> Seq("true")))
+    log.debug("Query:" + query)
+    val f = wSClient.url(url).withRequestTimeout(Duration.Inf).post(params(query))
     f.onFailure(wsFailureHandler(query))
     f
   }
 
-  protected def wsFailureHandler(aql: String): PartialFunction[Throwable, Unit] = {
-    case e: Throwable => log.error("WS Error:" + aql, e);
+  protected def wsFailureHandler(query: String): PartialFunction[Throwable, Unit] = {
+    case e: Throwable => log.error("WS Error:" + query, e)
       throw e
+  }
+
+  protected def params(query: String): Map[String, Seq[String]] = {
+    Map("statement" -> Seq(query), "mode" -> Seq("synchronous"), "include-results" -> Seq("true"))
   }
 }
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/datastore/IDataConn.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/datastore/IDataConn.scala
@@ -1,7 +1,8 @@
 package edu.uci.ics.cloudberry.zion.model.datastore
 
 import edu.uci.ics.cloudberry.util.Logging
-import play.api.libs.json.{JsValue, Json}
+import play.api.Logger
+import play.api.libs.json.{JsObject, JsString, JsValue, Json}
 import play.api.libs.ws.{WSClient, WSResponse}
 
 import scala.concurrent.duration.Duration
@@ -24,34 +25,37 @@ class AsterixConn(url: String, wSClient: WSClient)(implicit ec: ExecutionContext
 
   override def defaultQueryResponse: JsValue = defaultEmptyResponse
 
-  def postQuery(aql: String): Future[JsValue] = {
-    postWithCheckingStatus(aql, (ws: WSResponse) => ws.json, (ws: WSResponse) => defaultQueryResponse)
+  def postQuery(query: String): Future[JsValue] = {
+    postWithCheckingStatus(query, (ws: WSResponse) => {
+      ws.json.asInstanceOf[JsObject].value.get("results").get
+    }, (ws: WSResponse) => defaultQueryResponse)
   }
 
-  def postControl(aql: String): Future[Boolean] = {
-    postWithCheckingStatus(aql, (ws: WSResponse) => true, (ws: WSResponse) => false)
+  def postControl(query: String): Future[Boolean] = {
+    postWithCheckingStatus(query, (ws: WSResponse) => true, (ws: WSResponse) => false)
   }
 
-  protected def postWithCheckingStatus[T](aql: String, succeedHandler: WSResponse => T, failureHandler: WSResponse => T): Future[T] = {
-    post(aql).map { wsResponse =>
-      if (wsResponse.status == 200) {
+  protected def postWithCheckingStatus[T](query: String, succeedHandler: WSResponse => T, failureHandler: WSResponse => T): Future[T] = {
+    post(query).map { wsResponse =>
+      if (wsResponse.json.asInstanceOf[JsObject].value.get("status") == Some(JsString("success"))) {
         succeedHandler(wsResponse)
-      } else {
-        log.error("AQL failed:" + Json.prettyPrint(wsResponse.json))
+      }
+      else {
+        log.error("Query failed:" + Json.prettyPrint(wsResponse.json))
         failureHandler(wsResponse)
       }
     }
   }
 
-  def post(aql: String): Future[WSResponse] = {
-    log.debug("AQL:" + aql)
-    val f = wSClient.url(url).withRequestTimeout(Duration.Inf).post(aql)
-    f.onFailure(wsFailureHandler(aql))
+  def post(query: String): Future[WSResponse] = {
+    val f = wSClient.url(url).withRequestTimeout(Duration.Inf).post(Map("statement" -> Seq(query), "mode" -> Seq("synchronous"), "include-results" -> Seq("true")))
+    f.onFailure(wsFailureHandler(query))
     f
   }
 
   protected def wsFailureHandler(aql: String): PartialFunction[Throwable, Unit] = {
-    case e: Throwable => log.error("WS Error:" + aql, e); throw e
+    case e: Throwable => log.error("WS Error:" + aql, e);
+      throw e
   }
 }
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
@@ -134,7 +134,7 @@ class SQLPPGenerator extends AsterixQueryGenerator {
 
   private def parseLookup(lookups: Seq[LookupStatement],
                           exprMap: Map[String, FieldExpr]): ParsedResult = {
-    val producedExprs = mutable.Map.newBuilder[String, FieldExpr]
+    val producedExprs = mutable.LinkedHashMap.newBuilder[String, FieldExpr]
 
     val lookupStr = lookups.zipWithIndex.map {
       case (lookup, id) =>
@@ -170,7 +170,7 @@ class SQLPPGenerator extends AsterixQueryGenerator {
 
   private def parseUnnest(unnest: Seq[UnnestStatement],
                           exprMap: Map[String, FieldExpr]): ParsedResult = {
-    val producedExprs = mutable.Map.newBuilder[String, FieldExpr]
+    val producedExprs = mutable.LinkedHashMap.newBuilder[String, FieldExpr]
     val unnestTestStrs = new ListBuffer[String]
     val unnestStr = unnest.zipWithIndex.map {
       case (unnest, id) =>
@@ -191,7 +191,7 @@ class SQLPPGenerator extends AsterixQueryGenerator {
                            exprMap: Map[String, FieldExpr]): ParsedResult = {
     groupOpt match {
       case Some(group) =>
-        val producedExprs = mutable.Map.newBuilder[String, FieldExpr]
+        val producedExprs = mutable.LinkedHashMap.newBuilder[String, FieldExpr]
         val groupStrs = group.bys.map { by =>
           val fieldExpr = exprMap(by.field.name)
           val as = by.as.getOrElse(by.field)
@@ -221,7 +221,7 @@ class SQLPPGenerator extends AsterixQueryGenerator {
                           exprMap: Map[String, FieldExpr], query: Query): ParsedResult = {
     selectOpt match {
       case Some(select) =>
-        val producedExprs = mutable.Map.newBuilder[String, FieldExpr]
+        val producedExprs = mutable.LinkedHashMap.newBuilder[String, FieldExpr]
         val orderStrs = select.orderOn.zip(select.order).map {
           case (orderOn, order) =>
             val expr = exprMap(orderOn.name).refExpr
@@ -281,7 +281,7 @@ class SQLPPGenerator extends AsterixQueryGenerator {
                               queryStr: String): ParsedResult = {
     globalAggrOpt match {
       case Some(globalAggr) =>
-        val producedExprs = mutable.Map.newBuilder[String, FieldExpr]
+        val producedExprs = mutable.LinkedHashMap.newBuilder[String, FieldExpr]
         val aggr = globalAggr.aggregate
         val funcName = typeImpl.getAggregateStr(aggr.func)
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
@@ -134,6 +134,7 @@ class SQLPPGenerator extends AsterixQueryGenerator {
 
   private def parseLookup(lookups: Seq[LookupStatement],
                           exprMap: Map[String, FieldExpr]): ParsedResult = {
+    //use LinkedHashMap to preserve the order of fields
     val producedExprs = mutable.LinkedHashMap.newBuilder[String, FieldExpr]
 
     val lookupStr = lookups.zipWithIndex.map {

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
@@ -31,7 +31,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`hour` as `hour`
+          |select `hour` as `hour`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |where t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z')
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour` group as g;
@@ -45,7 +45,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`hour` as `hour`
+          |select `hour` as `hour`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
           |and contains(t.`text`, "virus")
@@ -60,7 +60,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`hour` as `hour`
+          |select `hour` as `hour`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |where t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour` group as g;
@@ -74,7 +74,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`state` as `state`,`hour` as `hour`
+          |select `hour` as `hour`,`state` as `state`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
           |and contains(t.`text`, "virus") and t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
@@ -88,7 +88,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select t.`user`.`id` as `user.id`,t.`create_at` as `create_at`,t.`id` as `id`
+          |select t.`create_at` as `create_at`,t.`id` as `id`,t.`user`.`id` as `user.id`
           |from twitter.ds_tweet t
           |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
           |and contains(t.`text`, "virus") and t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
@@ -105,7 +105,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`tag` as `tag`
+          |select `tag` as `tag`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |unnest t.`hashtags` `unnest0`
           |where not(is_null(t.`hashtags`)) and similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
@@ -124,7 +124,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_max( (select value g.t.`id` from g) ) as `max`,`hour` as `hour`
+          |select `hour` as `hour`,coll_max( (select value g.t.`id` from g) ) as `max`
           |from twitter.ds_tweet t
           |where t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z')
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour` group as g;
@@ -166,7 +166,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_avg( (select value g.t.`id` from g) ) as `avg`,`hour` as `hour`
+          |select `hour` as `hour`,coll_avg( (select value g.t.`id` from g) ) as `avg`
           |from twitter.ds_tweet t
           |where t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z')
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour` group as g;
@@ -180,7 +180,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`cell` as `cell`
+          |select `cell` as `cell`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
           |and contains(t.`text`, "virus")
@@ -195,7 +195,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`cell` as `cell`
+          |select `cell` as `cell`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
           |and contains(t.`text`, "virus")
@@ -211,7 +211,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`cell` as `cell`
+          |select `cell` as `cell`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
           |and contains(t.`text`, "virus")
@@ -227,7 +227,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`state` as `state`
+          |select `state` as `state`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
           |and contains(t.`text`, "virus")
@@ -241,7 +241,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`cell` as `cell`
+          |select `cell` as `cell`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |group by get_points(spatial_cell(t.`coordinate`, create_point(0.0,0.0), 0.001, 0.001))[0] as `cell` group as g;
         """.
@@ -268,7 +268,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`sec` as `sec`
+          |select `sec` as `sec`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1S") )) as `sec` group as g;
           | """.stripMargin.trim)
@@ -279,7 +279,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`min` as `min`
+          |select `min` as `min`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1M") )) as `min` group as g;
           | """.stripMargin.trim)
@@ -291,7 +291,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`day` as `day`
+          |select `day` as `day`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("P1D") )) as `day` group as g;
           | """.stripMargin.trim)
@@ -303,7 +303,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`week` as `week`
+          |select `week` as `week`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("P7D") )) as `week` group as g;
           | """.stripMargin.trim)
@@ -315,7 +315,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`month` as `month`
+          |select `month` as `month`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  year_month_duration("P1M") )) as `month` group as g;
           | """.stripMargin.trim)
@@ -327,7 +327,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
-          |select coll_count(g) as `count`,`year` as `year`
+          |select `year` as `year`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  year_month_duration("P1Y") )) as `year` group as g;
           | """.stripMargin.trim)
@@ -401,7 +401,7 @@ class SQLPPGeneratorTest extends Specification {
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """select coll_max(
-          |(select value c.`count` from (select coll_count(g) as `count`,`tag` as `tag`
+          |(select value c.`count` from (select `tag` as `tag`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |unnest t.`hashtags` `unnest0`
           |where not(is_null(t.`hashtags`)) and similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
@@ -532,7 +532,7 @@ class SQLPPGeneratorTest extends Specification {
       val query = new Query(dataset = TwitterDataSet, filter = filter, select = select)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
-        """select t.`user`.`id` as `user.id`,t.`create_at` as `create_at`,t.`id` as `id`
+        """select t.`create_at` as `create_at`,t.`id` as `id`,t.`user`.`id` as `user.id`
           |from twitter.ds_tweet t
           |where spatial_intersect(t.`coordinate`,
           |  create_rectangle(create_point(0.0,0.0),


### PR DESCRIPTION
Now we're able to integrate with SQLPPGenerator, and it works fine for the TwitterMap demo. Here we mainly changed the REST API of AsterixDB to use /query/server (https://cwiki.apache.org/confluence/display/ASTERIXDB/New+HTTP+API+Design).

This PR contains another change which ensures the generated SQL++ queries have the same order of fields as specified by cloudberry query. This is because although the query result, i.e., JSON objects, is an unordered Map, the front-end time series implicitly rely on the order of these fields (though it shouldn't).