### PR TITLE
Use fulltext index in AsterixDB

### DIFF
--- a/script/ingestTwitterToLocalCluster.sh
+++ b/script/ingestTwitterToLocalCluster.sh
@@ -74,7 +74,7 @@ create dataset ds_tweet(typeTweet) if not exists primary key id
 using compaction policy prefix (("max-mergable-component-size"="134217728"),("max-tolerance-component-count"="10")) with filter on create_at ;
 // with filter on create_at;
 //"using" "compaction" "policy" CompactionPolicy ( Configuration )? )?
-create index text_idx if not exists on ds_tweet("text") type keyword;
+create index text_idx if not exists on ds_tweet("text") type fulltext;
 //create index time_idx if not exists on ds_tweet(create_at) type btree;
 //create index location_idx if not exists on ds_tweet(coordinate) type rtree;
 //create index state_idx if not exists on ds_tweet(geo_tag.stateID) type btree;
@@ -88,7 +88,6 @@ create feed TweetFeed using socket_adapter
     ("type-name"="typeTweet"),
     ("format"="adm")
 );
-set wait-for-completion-feed "false";
 connect feed TweetFeed to dataset ds_tweet;
 start feed TweetFeed;
 EOF

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLFuncVisitor.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLFuncVisitor.scala
@@ -103,11 +103,8 @@ object AQLFuncVisitor {
                                     aqlExpr: String,
                                     relation: Relation,
                                     values: Seq[String]): String = {
-    val first = s"similarity-jaccard(word-tokens($aqlExpr), word-tokens('${values.head}')) > 0.0"
-    val rest = values.tail.map(
-      keyword => s"""and contains($aqlExpr, "$keyword")"""
-    )
-    (first +: rest).mkString("\n")
+    val words = values.map(w => s"'${w.trim}'").mkString("[", "," ,"]")
+    s"ftcontains($aqlExpr, $words, {'mode':'all'})"
   }
 
   private def validateNumberValue(relation: Relation, values: Seq[Any]): Unit = {

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AsterixQueryGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AsterixQueryGenerator.scala
@@ -34,6 +34,7 @@ trait AsterixImpl {
 
 
   val similarityJaccard: String
+  val fullTextContains: String
   val contains: String
   val wordTokens: String
 
@@ -195,11 +196,9 @@ abstract class AsterixQueryGenerator extends IQLGenerator {
     }
   }
 
-  protected def parseTextRelation(filter: FilterStatement,
-                                  fieldExpr: String): String = {
-    val first = s"${typeImpl.similarityJaccard}(${typeImpl.wordTokens}($fieldExpr), ${typeImpl.wordTokens}('${filter.values.head}')) > 0.0"
-    val rest = filter.values.tail.map(keyword => s"""and ${typeImpl.contains}($fieldExpr, "$keyword")""")
-    (first +: rest).mkString("\n")
+  protected def parseTextRelation(filter: FilterStatement, fieldExpr: String): String = {
+    val words = filter.values.map(w => s"'${w.asInstanceOf[String].trim}'").mkString("[", "," ,"]")
+    s"${typeImpl.fullTextContains}($fieldExpr, $words, {'mode':'all'})"
   }
 
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
@@ -35,6 +35,7 @@ object SQLPPAsterixImpl extends AsterixImpl {
   val getPoints: String = "get_points"
 
   val similarityJaccard: String = "similarity_jaccard"
+  val fullTextContains: String = "ftcontains"
   val contains: String = "contains"
   val wordTokens: String = "word_tokens"
 

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGeneratorTest.scala
@@ -35,8 +35,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus")
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'})
           |let $taggr := $t
           |group by $g0 := get-interval-start-datetime(interval-bin($t.'create_at', datetime('1990-01-01T00:00:00.000Z'),  day-time-duration("PT1H") )) with $taggr
           |return {
@@ -72,8 +71,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus") and $t.'create_at' >= datetime('2016-01-01T00:00:00.000Z') and $t.'create_at' < datetime('2016-12-01T00:00:00.000Z') and true
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'}) and $t.'create_at' >= datetime('2016-01-01T00:00:00.000Z') and $t.'create_at' < datetime('2016-12-01T00:00:00.000Z') and true
           |for $setgeo_tag_stateID in [ 37,51,24,11,10,34,42,9,44 ]
           |where $t.'geo_tag'.'stateID' = $setgeo_tag_stateID
           |let $taggr := $t
@@ -91,8 +89,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus") and $t.'create_at' >= datetime('2016-01-01T00:00:00.000Z') and $t.'create_at' < datetime('2016-12-01T00:00:00.000Z') and true
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'}) and $t.'create_at' >= datetime('2016-01-01T00:00:00.000Z') and $t.'create_at' < datetime('2016-12-01T00:00:00.000Z') and true
           |for $setgeo_tag_stateID in [ 37,51,24,11,10,34,42,9,44 ]
           |where $t.'geo_tag'.'stateID' = $setgeo_tag_stateID
           |order by $t.'create_at' desc
@@ -112,8 +109,7 @@ class AQLGeneratorTest extends Specification {
         """
           |for $g in (
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus") and $t.'create_at' >= datetime('2016-01-01T00:00:00.000Z') and $t.'create_at' < datetime('2016-12-01T00:00:00.000Z') and true
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'}) and $t.'create_at' >= datetime('2016-01-01T00:00:00.000Z') and $t.'create_at' < datetime('2016-12-01T00:00:00.000Z') and true
           |for $setgeo_tag_stateID in [ 37,51,24,11,10,34,42,9,44 ]
           |where $t.'geo_tag'.'stateID' = $setgeo_tag_stateID
           |where not(is-null($t.'hashtags'))
@@ -208,8 +204,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus")
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'})
           |let $taggr := $t
           |group by $g0 := get-points(spatial-cell($t.'coordinate', create-point(0.0,0.0), 0.1, 0.1))[0] with $taggr
           |return {
@@ -226,8 +221,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus")
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'})
           |let $taggr := $t
           |group by $g0 := get-points(spatial-cell($t.'coordinate', create-point(0.0,0.0), 0.01, 0.01))[0] with $taggr
           |return {
@@ -246,8 +240,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus")
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'})
           |let $taggr := $t
           |group by $g0 := get-points(spatial-cell($t.'coordinate', create-point(0.0,0.0), 0.001, 0.001))[0] with $taggr
           |return {
@@ -265,8 +258,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus")
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'})
           |let $taggr := $t
           |group by $g0 := round($t.'geo_tag'.'stateID'/10)*10 with $taggr
           |return {
@@ -298,8 +290,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus")
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'})
           |limit 10
           |offset 0
           |return
@@ -488,8 +479,7 @@ class AQLGeneratorTest extends Specification {
           |for $s in (
           |for $g in (
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus") and $t.'create_at' >= datetime('2016-01-01T00:00:00.000Z') and $t.'create_at' < datetime('2016-12-01T00:00:00.000Z') and true
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'}) and $t.'create_at' >= datetime('2016-01-01T00:00:00.000Z') and $t.'create_at' < datetime('2016-12-01T00:00:00.000Z') and true
           |for $setgeo_tag_stateID in [ 37,51,24,11,10,34,42,9,44 ]
           |where $t.'geo_tag'.'stateID' = $setgeo_tag_stateID
           |where not(is-null($t.'hashtags'))
@@ -541,8 +531,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus")
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'})
           |limit 0
           |offset 0
           |return
@@ -552,32 +541,6 @@ class AQLGeneratorTest extends Specification {
         """.stripMargin.trim
       )
     }
-
-    //TODO parseLookup should be able to handle multiple fields in the lookup statement
-    //        "translate lookup one table with one join key multiple select" in {
-    //          val populationDataSet = PopulationDataStore.DatasetName
-    //          val populationSchema = PopulationDataStore.PopulationSchema
-    //
-    //          val selectStatement = SelectStatement(Seq.empty, 0, 0, Seq("*", populationDataSet))
-    //          val lookup = LookupStatement(Seq("geo_tag.stateID"), populationDataSet, Seq("stateId"), Seq("population","stateId"),
-    //            Seq("population", "stateID"))
-    //          val filter = Seq(textFilter)
-    //          val query = new Query(TwitterDataSet, Seq(lookup), filter, Seq.empty, select = Some(selectStatement))
-    //          val result = parser.generate(query, Map(TwitterDataSet -> schema, populationDataSet -> populationSchema))
-    //          removeEmptyLine(result) must_== unifyNewLine(
-    //            """
-    //              |for $t in dataset twitter.ds_tweet
-    //              |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-    //              |and contains($t.'text', "virus")
-    //              |limit 0
-    //              |offset 0
-    //              |return
-    //              |{ '*': $t, 'twitter.US_population': for $l0 in dataset twitter.US_population
-    //              |where $t.'geo_tag'.'stateID' /* +indexnl */ = $l0.stateId
-    //              |return {'population' : $l0.population, 'stateID' : $l0.stateId}}
-    //            """.stripMargin.trim
-    //          )
-    //        }
 
     "translate lookup multiple table with one join key on each" in {
       val populationDataSet = PopulationDataStore.DatasetName
@@ -598,8 +561,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus")
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'})
           |limit 0
           |offset 0
           |return
@@ -627,8 +589,7 @@ class AQLGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
-          |and contains($t.'text', "virus")
+          |where ftcontains($t.'text', ['zika','virus'], {'mode':'all'})
           |let $population_aggr := (for $l0 in dataset twitter.US_population
           |where $t.'geo_tag'.'stateID' /* +indexnl */ = $l0.stateID
           |return $l0.population)[0]
@@ -707,7 +668,7 @@ class AQLGeneratorTest extends Specification {
           |create dataset zika(twitter.typeTweet) primary key id //with filter on 'create_at'
           |insert into dataset zika (
           |for $t in dataset twitter.ds_tweet
-          |where similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
+          |where ftcontains($t.'text', ['zika'], {'mode':'all'})
           |return $t
           |)
           |
@@ -723,7 +684,7 @@ class AQLGeneratorTest extends Specification {
         """
           |upsert into dataset zika (
           |for $t in dataset twitter.ds_tweet
-          |where $t.'create_at' >= datetime('2016-01-01T00:00:00.000Z') and $t.'create_at' < datetime('2016-12-01T00:00:00.000Z') and similarity-jaccard(word-tokens($t.'text'), word-tokens('zika')) > 0.0
+          |where $t.'create_at' >= datetime('2016-01-01T00:00:00.000Z') and $t.'create_at' < datetime('2016-12-01T00:00:00.000Z') and ftcontains($t.'text', ['zika'], {'mode':'all'})
           |return $t
           |)
         """.stripMargin.trim)

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
@@ -47,8 +47,7 @@ class SQLPPGeneratorTest extends Specification {
         """
           |select `hour` as `hour`,coll_count(g) as `count`
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour` group as g;
           | """.stripMargin.trim)
     }
@@ -76,8 +75,7 @@ class SQLPPGeneratorTest extends Specification {
         """
           |select `hour` as `hour`,`state` as `state`,coll_count(g) as `count`
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus") and t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'}) and t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
           |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour`,t.geo_tag.stateID as `state` group as g;
           | """.stripMargin.trim)
     }
@@ -90,8 +88,7 @@ class SQLPPGeneratorTest extends Specification {
         """
           |select t.`create_at` as `create_at`,t.`id` as `id`,t.`user`.`id` as `user.id`
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus") and t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'}) and t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
           |order by t.`create_at` desc
           |limit 100
           |offset 0;
@@ -108,8 +105,7 @@ class SQLPPGeneratorTest extends Specification {
           |select `tag` as `tag`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |unnest t.`hashtags` `unnest0`
-          |where not(is_null(t.`hashtags`)) and similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus") and t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
+          |where not(is_null(t.`hashtags`)) and ftcontains(t.`text`, ['zika','virus'], {'mode':'all'}) and t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
           |group by `unnest0` as `tag` group as g
           |order by `count` desc
           |limit 10
@@ -182,8 +178,7 @@ class SQLPPGeneratorTest extends Specification {
         """
           |select `cell` as `cell`,coll_count(g) as `count`
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |group by get_points(spatial_cell(t.`coordinate`, create_point(0.0,0.0), 0.1, 0.1))[0] as `cell` group as g;
         """.stripMargin.trim)
     }
@@ -197,8 +192,7 @@ class SQLPPGeneratorTest extends Specification {
         """
           |select `cell` as `cell`,coll_count(g) as `count`
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |group by get_points(spatial_cell(t.`coordinate`, create_point(0.0,0.0), 0.01, 0.01))[0] as `cell` group as g;
         """.
           stripMargin.trim)
@@ -213,8 +207,7 @@ class SQLPPGeneratorTest extends Specification {
         """
           |select `cell` as `cell`,coll_count(g) as `count`
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |group by get_points(spatial_cell(t.`coordinate`, create_point(0.0,0.0), 0.001, 0.001))[0] as `cell` group as g;
         """.
           stripMargin.trim)
@@ -229,8 +222,7 @@ class SQLPPGeneratorTest extends Specification {
         """
           |select `state` as `state`,coll_count(g) as `count`
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |group by round(t.`geo_tag`.`stateID`/10)*10 as `state` group as g;
           | """.stripMargin.trim)
     }
@@ -256,8 +248,7 @@ class SQLPPGeneratorTest extends Specification {
         """
           |select value t
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |limit 10
           |offset 0;
           | """.stripMargin.trim)
@@ -404,8 +395,7 @@ class SQLPPGeneratorTest extends Specification {
           |(select value c.`count` from (select `tag` as `tag`,coll_count(g) as `count`
           |from twitter.ds_tweet t
           |unnest t.`hashtags` `unnest0`
-          |where not(is_null(t.`hashtags`)) and similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus") and t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
+          |where not(is_null(t.`hashtags`)) and ftcontains(t.`text`, ['zika','virus'], {'mode':'all'}) and t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44 ]
           |group by `unnest0` as `tag` group as g
           |order by `count` desc
           |limit 10
@@ -440,8 +430,7 @@ class SQLPPGeneratorTest extends Specification {
           |select t.`favorite_count` as `favorite_count`,t.`geo_tag`.`countyID` as `geo_tag.countyID`,t.`user_mentions` as `user_mentions`,l0.`population` as `population`,t.`user`.`id` as `user.id`,t.`geo_tag`.`cityID` as `geo_tag.cityID`,t.`is_retweet` as `is_retweet`,t.`text` as `text`,t.`retweet_count` as `retweet_count`,t.`in_reply_to_user` as `in_reply_to_user`,t.`id` as `id`,t.`coordinate` as `coordinate`,t.`in_reply_to_status` as `in_reply_to_status`,t.`user`.`status_count` as `user.status_count`,t.`geo_tag`.`stateID` as `geo_tag.stateID`,t.`create_at` as `create_at`,t.`lang` as `lang`,t.`hashtags` as `hashtags`
           |from twitter.ds_tweet t
           |left outer join twitter.US_population l0 on l0.`stateID` = t.`geo_tag`.`stateID`
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |limit 0
           |offset 0;""".stripMargin.trim
       )
@@ -462,8 +451,7 @@ class SQLPPGeneratorTest extends Specification {
           |select t.`favorite_count` as `favorite_count`,t.`geo_tag`.`countyID` as `geo_tag.countyID`,t.`user_mentions` as `user_mentions`,l0.`population` as `population`,l0.`stateID` as `stateID`,t.`user`.`id` as `user.id`,t.`geo_tag`.`cityID` as `geo_tag.cityID`,t.`is_retweet` as `is_retweet`,t.`text` as `text`,t.`retweet_count` as `retweet_count`,t.`in_reply_to_user` as `in_reply_to_user`,t.`id` as `id`,t.`coordinate` as `coordinate`,t.`in_reply_to_status` as `in_reply_to_status`,t.`user`.`status_count` as `user.status_count`,t.`geo_tag`.`stateID` as `geo_tag.stateID`,t.`create_at` as `create_at`,t.`lang` as `lang`,t.`hashtags` as `hashtags`
           |from twitter.ds_tweet t
           |left outer join twitter.US_population l0 on l0.`stateID` = t.`geo_tag`.`stateID`
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |limit 0
           |offset 0;""".stripMargin.trim
       )
@@ -492,8 +480,7 @@ class SQLPPGeneratorTest extends Specification {
           |from twitter.ds_tweet t
           |left outer join twitter.US_population l0 on l0.`stateID` = t.`geo_tag`.`stateID`
           |left outer join twitter.US_literacy l1 on l1.`stateID` = t.`geo_tag`.`stateID`
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |limit 0
           |offset 0;""".stripMargin.trim
       )
@@ -519,8 +506,7 @@ class SQLPPGeneratorTest extends Specification {
         """select `state` as `state`,coll_sum( (select value g.l0.`population` from g) ) as `sum`
           |from twitter.ds_tweet t
           |left outer join twitter.US_population l0 on l0.`stateID` = t.`geo_tag`.`stateID`
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |group by t.geo_tag.stateID as `state` group as g;""".stripMargin.trim
       )
     }
@@ -560,8 +546,7 @@ class SQLPPGeneratorTest extends Specification {
           |from (
           |select `state` as `state`,coll_count(g) as `count`
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |group by t.geo_tag.stateID as `state` group as g
           |) tt
           |left outer join twitter.US_population ll0 on ll0.`stateID` = tt.`state`;""".stripMargin.trim
@@ -585,8 +570,7 @@ class SQLPPGeneratorTest extends Specification {
           |from (
           |select `state` as `state`,coll_count(g) as `count`
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |group by t.geo_tag.stateID as `state` group as g
           |) tt
           |left outer join twitter.US_population ll0 on ll0.`stateID` = tt.`state`
@@ -615,8 +599,7 @@ class SQLPPGeneratorTest extends Specification {
           |select `state` as `state`,coll_min( (select value g.l0.`population` from g) ) as `min`
           |from twitter.ds_tweet t
           |left outer join twitter.US_population l0 on l0.`stateID` = t.`geo_tag`.`stateID`
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |group by t.geo_tag.stateID as `state` group as g
           |) tt
           |left outer join twitter.US_literacy ll0 on ll0.`stateID` = tt.`state`
@@ -641,8 +624,7 @@ class SQLPPGeneratorTest extends Specification {
           |from (
           |select `state` as `state`
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
-          |and contains(t.`text`, "virus")
+          |where ftcontains(t.`text`, ['zika','virus'], {'mode':'all'})
           |group by t.geo_tag.stateID as `state` group as g
           |) tt
           |left outer join twitter.US_population ll0 on ll0.`stateID` = tt.`state`
@@ -694,7 +676,7 @@ class SQLPPGeneratorTest extends Specification {
           |insert into zika (
           |select value t
           |from twitter.ds_tweet t
-          |where similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
+          |where ftcontains(t.`text`, ['zika'], {'mode':'all'})
           |);""".stripMargin.trim)
     }
   }
@@ -708,7 +690,7 @@ class SQLPPGeneratorTest extends Specification {
           |upsert into zika (
           |select value t
           |from twitter.ds_tweet t
-          |where t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and similarity_jaccard(word_tokens(t.`text`), word_tokens('zika')) > 0.0
+          |where t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z') and ftcontains(t.`text`, ['zika'], {'mode':'all'})
           |);
         """.stripMargin.trim)
     }


### PR DESCRIPTION
This PR replace the `keyword` index with the newest `fulltext` index supported in the recent AsterixDB.

The index type in the ingestion script is updated. And the `parseTextRelation` is converted to use `ftcontains` function.

#300 

Blocked by the issue [AsterixDB-1877](https://issues.apache.org/jira/browse/ASTERIXDB-1877)