### PR TITLE
[#ISSUE 305]Add "DeleteRecord" query for deleting records from the backend db

### DIFF
--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
@@ -97,10 +97,18 @@ class SQLPPGenerator extends AsterixQueryGenerator {
        |)""".stripMargin
   }
 
+  protected def parseDelete(delete: DeleteRecord, schemaMap: Map[String, Schema]): String = {
+    val exprMap: Map[String, FieldExpr] = initExprMap(delete.dataset, schemaMap)
+    val queryBuilder = new StringBuilder()
+    queryBuilder.append(s"delete from ${delete.dataset} $sourceVar")
+    parseFilter(delete.filters, exprMap, Seq.empty, queryBuilder)
+    return queryBuilder.toString()
+  }
+
   def parseQuery(query: Query, schemaMap: Map[String, Schema]): String = {
     val queryBuilder = new mutable.StringBuilder()
 
-    val exprMap: Map[String, FieldExpr] = initExprMap(query, schemaMap)
+    val exprMap: Map[String, FieldExpr] = initExprMap(query.dataset, schemaMap)
     val fromStr = s"from ${query.dataset} $sourceVar".trim
     queryBuilder.append(fromStr)
 
@@ -283,7 +291,6 @@ class SQLPPGenerator extends AsterixQueryGenerator {
         queryBuilder.insert(0, projectStr + "\n")
         ParsedResult(Seq.empty, exprMap)
     }
-
   }
 
   private def parseProject(exprMap: Map[String, FieldExpr]): String = {

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
@@ -98,6 +98,9 @@ class SQLPPGenerator extends AsterixQueryGenerator {
   }
 
   protected def parseDelete(delete: DeleteRecord, schemaMap: Map[String, Schema]): String = {
+    if (delete.filters.isEmpty) {
+      throw new QueryParsingException("Filter condition is required for DeleteRecord query.")
+    }
     val exprMap: Map[String, FieldExpr] = initExprMap(delete.dataset, schemaMap)
     val queryBuilder = new StringBuilder()
     queryBuilder.append(s"delete from ${delete.dataset} $sourceVar")

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
@@ -105,6 +105,8 @@ case class CreateDataSet(dataset: String, schema: Schema, createIffNotExist: Boo
 
 case class UpsertRecord(dataset: String, records: JsArray) extends IWriteQuery
 
+case class DeleteRecord(dataset: String, filters: Seq[FilterStatement]) extends IWriteQuery
+
 trait Statement
 
 /**

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
@@ -697,14 +697,6 @@ class SQLPPGeneratorTest extends Specification {
   }
 
   "SQLPPGenerator deleteRecord" should {
-    "generate the delete query without filter" in {
-      val sql = parser.generate(DeleteRecord(TwitterDataSet, Seq.empty), Map(TwitterDataSet -> TwitterDataStore.TwitterSchema))
-      removeEmptyLine(sql) must_== unifyNewLine(
-        """
-          |delete from twitter.ds_tweet t;
-        """.stripMargin.trim)
-    }
-
     "generate the delete query " in {
       val sql = parser.generate(DeleteRecord(TwitterDataSet, Seq(timeFilter)), Map(TwitterDataSet -> TwitterDataStore.TwitterSchema))
       removeEmptyLine(sql) must_== unifyNewLine(

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
@@ -695,4 +695,24 @@ class SQLPPGeneratorTest extends Specification {
         """.stripMargin.trim)
     }
   }
+
+  "SQLPPGenerator deleteRecord" should {
+    "generate the delete query without filter" in {
+      val sql = parser.generate(DeleteRecord(TwitterDataSet, Seq.empty), Map(TwitterDataSet -> TwitterDataStore.TwitterSchema))
+      removeEmptyLine(sql) must_== unifyNewLine(
+        """
+          |delete from twitter.ds_tweet t;
+        """.stripMargin.trim)
+    }
+
+    "generate the delete query " in {
+      val sql = parser.generate(DeleteRecord(TwitterDataSet, Seq(timeFilter)), Map(TwitterDataSet -> TwitterDataStore.TwitterSchema))
+      removeEmptyLine(sql) must_== unifyNewLine(
+        """
+          |delete from twitter.ds_tweet t
+          |where t.`create_at` >= datetime('2016-01-01T00:00:00.000Z') and t.`create_at` < datetime('2016-12-01T00:00:00.000Z');
+          |""".stripMargin.trim)
+    }
+  }
+
 }


### PR DESCRIPTION
Added a "DeleteRecord" for deleting records from the backup db.

This query has two parameters, i.e., dataset and a seq of filters. The semantics is that records satisfying the filters condition would be deleted from the given data set (basically the same way of SQL)