### PR TITLE
Fix JSONParser get datasets only returns the first dataset for a query

### DIFF
--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
@@ -13,12 +13,7 @@ class JSONParser extends IJSONParser {
 
   override def getDatasets(json: JsValue): Set[String] = {
     val datasets = (json \\ "dataset").filter(_.isInstanceOf[JsString]).map(_.asInstanceOf[JsString].value)
-    if (datasets.isEmpty) {
-      datasets.toSet
-    } else {
-      //TODO currently do not handle lookup queries
-      Set(datasets.head)
-    }
+    datasets.toSet
   }
 
   /**

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParserTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParserTest.scala
@@ -231,4 +231,18 @@ class JSONParserTest extends Specification {
       option.sliceMills must_== 1234
     }
   }
+
+
+  "JSONParser getDatasets" should{
+    "parse a single dataset" in{
+      val datasets = parser.getDatasets(zikaJSON)
+      datasets must_== Seq("twitter.ds_tweet")
+    }
+
+    "parse two datasets" in{
+      val datasets = parser.getDatasets(groupLookupJSON)
+      datasets must_== Seq("twitter.ds_tweet", "twitter.US_population")
+    }
+  }
+  
 }


### PR DESCRIPTION
Previously, we ignored lookup queries and `JSONParser.getDatasets` only returns the first dataset by a query.

This bug is fixed by this PR.