### PR TITLE
Add implementation of string "matches" and "!=" operator in SQLPPGenerator

### DIFF
--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AsterixQueryGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AsterixQueryGenerator.scala
@@ -123,7 +123,7 @@ abstract class AsterixQueryGenerator extends IQLGenerator {
   protected def parseUpsert(query: UpsertRecord, schemaMap: Map[String, Schema]): String
 
   protected def parseDelete(query: DeleteRecord, schemaMap: Map[String, Schema]): String
-  
+
   def calcResultSchema(query: Query, schema: Schema): Schema = {
     if (query.lookup.isEmpty && query.groups.isEmpty && query.select.isEmpty) {
       schema.copy()
@@ -158,7 +158,7 @@ abstract class AsterixQueryGenerator extends IQLGenerator {
       case DataType.Point =>
         parsePointRelation(filter, fieldExpr)
       case DataType.Boolean => ???
-      case DataType.String => ???
+      case DataType.String => parseStringRelation(filter, fieldExpr)
       case DataType.Text =>
         parseTextRelation(filter, fieldExpr)
       case DataType.Bag => ???
@@ -197,6 +197,23 @@ abstract class AsterixQueryGenerator extends IQLGenerator {
       }
     }
   }
+
+  protected def parseStringRelation(filter: FilterStatement, fieldExpr: String): String = {
+    filter.relation match {
+      case Relation.matches => {
+        val values = filter.values.map(_.asInstanceOf[String])
+        s"""$fieldExpr="${values(0)}""""
+      }
+      case Relation.!= => {
+        val values = filter.values.map(_.asInstanceOf[String])
+        s"""$fieldExpr!="${values(0)}""""
+      }
+      case Relation.contains => ???
+
+    }
+
+  }
+
 
   protected def parseTextRelation(filter: FilterStatement, fieldExpr: String): String = {
     val words = filter.values.map(w => s"'${w.asInstanceOf[String].trim}'").mkString("[", ",", "]")

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryValidator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryValidator.scala
@@ -67,6 +67,7 @@ object QueryValidator {
         validatePointRelation(filter.relation, filter.values)
       case DataType.Boolean =>
       case DataType.String =>
+        validateStringRelation(filter.relation, filter.values)
       case DataType.Text =>
         validateTextRelation(filter.relation, filter.values)
       case DataType.Bag =>
@@ -117,6 +118,18 @@ object QueryValidator {
         if (values.size != 1) throw new QueryParsingException(s"relation: $relation require one parameter")
     }
   }
+
+  def validateStringRelation(relation: Relation, values: Seq[Any]): Unit = {
+    requireOrThrow(values.forall(_.isInstanceOf[String]), s"values contain non compatible data type for relation: $relation.")
+
+    relation match {
+      case Relation.matches | Relation.!= =>
+        if (values.size != 1) throw new QueryParsingException(s"relation: $relation require one parameter")
+      case Relation.contains => ???
+    }
+
+  }
+
 
   def validateTimeRelation(relation: Relation, values: Seq[Any]): Unit = {
     //required string format : http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
@@ -38,6 +38,36 @@ class SQLPPGeneratorTest extends Specification {
           | """.stripMargin.trim)
     }
 
+
+    "translate a simple filter with string not match" in {
+      val filter = Seq(langNotMatchFilter)
+      val group = GroupStatement(Seq(byHour), Seq(aggrCount))
+      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
+      removeEmptyLine(result) must_== unifyNewLine(
+        """
+          |select `hour` as `hour`,coll_count(g) as `count`
+          |from twitter.ds_tweet t
+          |where t.`lang`!="en"
+          |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour` group as g;
+          | """.stripMargin.trim)
+    }
+
+
+    "translate a simple filter with string matches" in {
+      val filter = Seq(langMatchFilter)
+      val group = GroupStatement(Seq(byHour), Seq(aggrCount))
+      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
+      removeEmptyLine(result) must_== unifyNewLine(
+        """
+          |select `hour` as `hour`,coll_count(g) as `count`
+          |from twitter.ds_tweet t
+          |where t.`lang`="en"
+          |group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour` group as g;
+          | """.stripMargin.trim)
+    }
+    
     "translate a text contain filter and group by time query" in {
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrCount))

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestQuery.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestQuery.scala
@@ -22,6 +22,8 @@ object TestQuery {
   val createAt = twitterField("create_at").asInstanceOf[TimeField]
   val hashtags = twitterField("hashtags")
   val text = twitterField("text")
+  val lang = twitterField("lang")
+
   val tag = Field.as(hashtags, "tag")
   val geoStateID = twitterField("geo_tag.stateID")
   val isRetweet = twitterField("is_retweet")
@@ -48,6 +50,8 @@ object TestQuery {
   val retweetFilter = FilterStatement(isRetweet, None, Relation.isTrue, Seq.empty)
   val bagFilter = FilterStatement(hashtags, None, Relation.contains, Seq(BagField("tags", DataType.String, false)))
   val pointFilter = FilterStatement(coordinate, None, Relation.inRange, Seq(Seq(0.0, 0.0), Seq(1.0, 1.0)))
+  val langMatchFilter =  FilterStatement(lang, None, Relation.matches, Seq("en"))
+  val langNotMatchFilter =  FilterStatement(lang, None, Relation.!=, Seq("en"))
 
   val intValues = Seq(1)
   val stringValue = Seq("English")


### PR DESCRIPTION
Previously, SQLPPGenerator does not support filter on string types (such as "matches" and "!="). This PR adds the implementation of "matches" and "!=" comparisons for strings.