### PR TITLE
Sentiment UI

### DIFF
--- a/neo/public/javascripts/common/services.js
+++ b/neo/public/javascripts/common/services.js
@@ -3,6 +3,7 @@ angular.module('cloudberry.common', [])
     return {
       normalizationUpscaleFactor: 1000 * 1000,
       normalizationUpscaleText: "/M",
+      sentimentUpperBound: 4,
       getPopulationTarget: function(parameters){
         switch (parameters.geoLevel) {
           case "state":

--- a/neo/public/javascripts/map/controllers.js
+++ b/neo/public/javascripts/map/controllers.js
@@ -259,8 +259,8 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
           } else if ($scope.status.logicLevel === 'city') {
             geoData = $scope.geojsonData.city;
           } else {
-            console.error("Error: Illegal value of logicLevel, set to default: state")
-            $scope.status.logicLevel = 'state'
+            console.error("Error: Illegal value of logicLevel, set to default: state");
+            $scope.status.logicLevel = 'state';
             geoData = $scope.geojsonData.state;
           }
         }
@@ -368,7 +368,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
 
     /**
      * Update map based on a set of spatial query result cells
-     * @param    [Array]     mapPlotData, an array of coordinate and weight objects
+     * @param    result  =>  mapPlotData, an array of coordinate and weight objects
      */
     function drawMap(result) {
 
@@ -408,7 +408,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
       }
 
       function style(feature) {
-        if (!feature.properties.count || feature.properties.count == 0){
+        if (!feature.properties.count || feature.properties.count === 0){
           return {
             fillColor: '#f7f7f7',
             weight: 2,
@@ -520,12 +520,13 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
       }
 
       function initNormalizeToggle() {
-        $('#toggle-normalize').bootstrapToggle({
+        var toggle = $('#toggle-normalize');
+        toggle.bootstrapToggle({
           on: "By Population"
         });
         if($scope.doSentiment){
-          $('#toggle-normalize').bootstrapToggle('off');
-          $('#toggle-normalize').bootstrapToggle('disable');
+          toggle.bootstrapToggle('off');
+          toggle.bootstrapToggle('disable');
         }
       }
 
@@ -624,23 +625,23 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
       },
 
       function(newResult, oldValue) {
-        if (newResult['mapResult'] != oldValue['mapResult']) {
+        if (newResult['mapResult'] !== oldValue['mapResult']) {
             $scope.result = newResult['mapResult'];
-            if (Object.keys($scope.result).length != 0) {
+            if (Object.keys($scope.result).length !== 0) {
                 $scope.status.init = false;
                 drawMap($scope.result);
             } else {
                 drawMap($scope.result);
             }
         }
-        if (newResult['totalCount'] != oldValue['totalCount']) {
+        if (newResult['totalCount'] !== oldValue['totalCount']) {
             $scope.totalCount = newResult['totalCount'];
         }
-        if(newResult['doNormalization'] != oldValue['doNormalization']) {
+        if(newResult['doNormalization'] !== oldValue['doNormalization']) {
           $scope.doNormalization = newResult['doNormalization'];
           drawMap($scope.result);
         }
-        if(newResult['doSentiment'] != oldValue['doSentiment']) {
+        if(newResult['doSentiment'] !== oldValue['doSentiment']) {
           $scope.doSentiment = newResult['doSentiment'];
           drawMap($scope.result);
         }

--- a/neo/public/javascripts/map/controllers.js
+++ b/neo/public/javascripts/map/controllers.js
@@ -376,9 +376,9 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
       var sentimentColors = $scope.styles.sentimentColors;
 
       function getSentimentColor(d) {
-        if( d < 4 / 3) {    // 1/3
+        if( d < cloudberryConfig.sentimentUpperBound / 3) {    // 1/3
           return sentimentColors[0];
-        } else if( d < 2 * 4 / 3){    // 2/3
+        } else if( d < 2 * cloudberryConfig.sentimentUpperBound / 3){    // 2/3
           return sentimentColors[1];
         } else{     // 3/3
           return sentimentColors[2];

--- a/neo/public/javascripts/map/controllers.js
+++ b/neo/public/javascripts/map/controllers.js
@@ -375,28 +375,35 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
       var colors = $scope.styles.colors;
       var sentimentColors = $scope.styles.sentimentColors;
 
+      function getSentimentColor(d) {
+        if( d < 4 / 3) {    // 1/3
+          return sentimentColors[0];
+        } else if( d < 2 * 4 / 3){    // 2/3
+          return sentimentColors[1];
+        } else{     // 3/3
+          return sentimentColors[2];
+        }
+      }
+
+      function getCountColor(d) {
+        if(!d || d <= 0) {
+          d = 0;
+        } else if (d ===1 ){
+          d = 1;
+        } else {
+          d = Math.ceil(Math.log10(d));
+          if(d <= 0) // treat smaller counts the same as 0
+            d = 0
+        }
+        d = Math.min(d, colors.length-1);
+        return colors[d];
+      }
+
       function getColor(d) {
         if($scope.doSentiment){  // 0 <= d <= 4
-          if( d < 1 * 4 / 3) {
-            return sentimentColors[0];
-          } else if( d < 2 * 4 / 3){
-            return sentimentColors[1];
-          } else{
-            return sentimentColors[2];
-          }
-        }
-        else{
-          if(!d || d <= 0) {
-            d = 0;
-          } else if (d ===1 ){
-            d = 1;
-          } else {
-            d = Math.ceil(Math.log10(d));
-            if(d <= 0) // treat smaller counts the same as 0
-              d = 0
-          }
-          d = Math.min(d, colors.length-1);
-          return colors[d];
+          return getSentimentColor(d)
+        } else {
+          return getCountColor(d)
         }
       }
 
@@ -426,8 +433,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
         // beautify 0.0000123 => 1.23e-5, 1.123 => 1.1
         if(geo["properties"]["count"] < 1){
           geo["properties"]["countText"] = geo["properties"]["count"].toExponential(1);
-        }
-        else{
+        } else{
           geo["properties"]["countText"] = geo["properties"]["count"].toFixed(1);
         }
         geo["properties"]["countText"] += cloudberryConfig.normalizationUpscaleText; // "/M"
@@ -462,8 +468,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
                   // TODO: change fake random number to real sentiment (0-4)
                   geo['properties']['count'] = Math.random() * 4;
                   geo["properties"]["countText"] = geo["properties"]["count"].toFixed(1);
-                }
-                else{
+                } else {
                   if ($scope.doNormalization)
                     setNormalizedCount(geo, r);
                   else
@@ -504,8 +509,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
             '<i style="background:' + getColor(2) + '"></i>Neutral<br>';
           div.innerHTML +=
             '<i style="background:' + getColor(3) + '"></i>Positive<br>';
-        }
-        else{
+        } else {
           var grades = new Array(colors.length -1); //[1, 10, 100, 1000, 10000, 100000]
 
           for(var i = 0; i < grades.length; i++){
@@ -526,8 +530,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
 
             if($scope.doNormalization){
               return returnText + cloudberryConfig.normalizationUpscaleText; //["1/M", "10/M", "100/M", "1K/M", "10K/M", "100K/M"];
-            }
-            else{
+            } else {
               return returnText; //["1", "10", "100", "1K", "10K", "100K"];
             }
           });
@@ -622,8 +625,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
             if (Object.keys($scope.result).length != 0) {
                 $scope.status.init = false;
                 drawMap($scope.result);
-            }
-            else {
+            } else {
                 drawMap($scope.result);
             }
         }

--- a/neo/public/javascripts/map/controllers.js
+++ b/neo/public/javascripts/map/controllers.js
@@ -497,7 +497,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
       $scope.legend.onAdd = function(map) {
         var div = L.DomUtil.create('div', 'info legend');
         if($scope.doSentiment){
-          div.setAttribute("title", "Sentiment: 0-4, Negative-Positive");  // add tool-tips for the legend
+          div.setAttribute("title", "Sentiment Score: Negative(0)-Positive(4)");  // add tool-tips for the legend
           div.innerHTML +=
             '<i style="background:' + getColor(1) + '"></i>Negative<br>';
           div.innerHTML +=
@@ -543,7 +543,9 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
           }
           div.innerHTML += '<i style="background:' + getColor(grades[i-1]*10) + '"></i> ' + gName[i-1] + '+';
         }
+
         return div;
+
       };
       if ($scope.map)
         $scope.legend.addTo($scope.map);
@@ -571,6 +573,10 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
         $('#toggle-normalize').bootstrapToggle({
           on: "By Population"
         });
+        if($scope.doSentiment){
+          $('#toggle-normalize').bootstrapToggle('off');
+          $('#toggle-normalize').bootstrapToggle('disable');
+        }
       }
 
       // add toggle sentiment analysis


### PR DESCRIPTION
To show the sentiment score on the map.

Details:
- Use random number for 0 - 4 to fake sentiment score for now
- Use sentiment score as the `count` for each polygon
- Disable the normalization toggle and set it to off when the sentiment toggle is on because it makes no sense to normalize sentiment scores
![screen shot 2017-04-26 at 15 20 06](https://cloud.githubusercontent.com/assets/12385178/25460649/9ca327b4-2a99-11e7-82bd-293de46f4198.jpg)
