### PR TITLE
Implemented "Append" statement

### DIFF
--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGenerator.scala
@@ -87,7 +87,7 @@ class AQLGenerator extends IQLGenerator {
         }
       }
     }
-
+    
     val varMapAfterLookup = parseLookup(query.lookup, schemaVars, schemaMap)
     val filter = parseFilter(query.filter, varMapAfterLookup)
     val (unnest, varMapAfterUnnest) = parseUnnest(query.unnest, varMapAfterLookup)

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AsterixQueryGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/AsterixQueryGenerator.scala
@@ -71,6 +71,8 @@ abstract class AsterixQueryGenerator extends IQLGenerator {
 
   protected def sourceVar: String
 
+  protected def appendVar: String
+
   protected def lookupVar: String
 
   protected def unnestVar: String

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
@@ -1,6 +1,7 @@
 package edu.uci.ics.cloudberry.zion.model.impl
 
 import edu.uci.ics.cloudberry.zion.model.datastore.{FieldNotFound, IJSONParser, JsonRequestException, QueryParsingException}
+import edu.uci.ics.cloudberry.zion.model.impl.DataSetInfo.parseLevels
 import edu.uci.ics.cloudberry.zion.model.schema.Relation.Relation
 import edu.uci.ics.cloudberry.zion.model.schema._
 import play.api.libs.functional.syntax._
@@ -185,6 +186,30 @@ object JSONParser {
       (JsPath \ "as").formatNullable[String]
     ) (UnresolvedByStatement.apply, unlift(UnresolvedByStatement.unapply))
 
+
+  implicit val typeFormat: Format[DataType.DataType] = new Format[DataType.DataType] {
+    override def reads(json: JsValue): JsResult[DataType.DataType] = {
+      val fieldType = json.as[String]
+      DataType.values.find(_.toString == fieldType) match {
+        case Some(v) => JsSuccess(v)
+        case None => JsError(s"Invalid field type: $fieldType")
+      }
+    }
+
+    override def writes(dataType: DataType.DataType): JsValue = {
+      JsString(dataType.toString)
+    }
+
+  }
+
+  implicit val appendFormat: Format[UnresolvedAppendStatement] = (
+    (JsPath \ "field").format[String] and
+      (JsPath \ "definition").format[String] and
+      (JsPath \ "type").format[DataType.DataType] and
+      (JsPath \ "as").format[String]
+    ) (UnresolvedAppendStatement.apply, unlift(UnresolvedAppendStatement.unapply))
+
+
   implicit val lookupFormat: Format[UnresolvedLookupStatement] = (
     (JsPath \ "joinKey").format[Seq[String]] and
       (JsPath \ "dataset").format[String] and
@@ -245,6 +270,10 @@ object JSONParser {
   // TODO find better name for 'global'
   implicit val queryFormat: Format[UnresolvedQuery] = (
     (JsPath \ "dataset").format[String] and
+      (JsPath \ "append").formatNullable[Seq[UnresolvedAppendStatement]].inmap[Seq[UnresolvedAppendStatement]](
+        o => o.getOrElse(Seq.empty[UnresolvedAppendStatement]),
+        s => if (s.isEmpty) None else Some(s)
+      ) and
       (JsPath \ "lookup").formatNullable[Seq[UnresolvedLookupStatement]].inmap[Seq[UnresolvedLookupStatement]](
         o => o.getOrElse(Seq.empty[UnresolvedLookupStatement]),
         s => if (s.isEmpty) None else Some(s)

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlanner.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlanner.scala
@@ -28,7 +28,7 @@ class QueryPlanner {
         kwFilter.values.map { wordAny =>
           val word = wordAny.asInstanceOf[String]
           val wordFilter = FilterStatement(kwFilter.field, None, Relation.contains, Seq(word))
-          val wordQuery = Query(query.dataset, Seq.empty, Seq(wordFilter), Seq.empty, None, None)
+          val wordQuery = Query(query.dataset, Seq.empty, Seq.empty, Seq(wordFilter), Seq.empty, None, None)
           CreateView(getViewKey(query.dataset, word), wordQuery)
         }
       }

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryResolver.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryResolver.scala
@@ -32,7 +32,8 @@ object QueryResolver {
   private def resolveQuery(query: UnresolvedQuery, schemaMap: Map[String, Schema]): Query = {
     val schema = schemaMap(query.dataset)
     val fieldMap = schema.fieldMap
-    val (lookup, fieldMapAfterLookup) = resolveLookups(query.lookup, fieldMap, schemaMap)
+    val (append, fieldMapAfterAppend) = resolveAppends(query.append, fieldMap)
+    val (lookup, fieldMapAfterLookup) = resolveLookups(query.lookup, fieldMapAfterAppend, schemaMap)
     val (unnest, fieldMapAfterUnnest) = resolveUnnests(query.unnest, fieldMapAfterLookup)
 
     val (filter, fieldMapAfterFilter) = resolveFilters(query.filter, fieldMapAfterUnnest)
@@ -42,8 +43,22 @@ object QueryResolver {
 
     val (globalAggr, fieldMapAfterGlobalAggr) = resolveGlobalAggregate(query.globalAggr, fieldMapAfterSelect)
 
-    Query(query.dataset, lookup, filter, unnest, groups, select, globalAggr, query.estimable)
+    Query(query.dataset, append, lookup, filter, unnest, groups, select, globalAggr, query.estimable)
   }
+
+  private def resolveAppends(appends: Seq[UnresolvedAppendStatement],
+                             fieldMap: Map[String, Field]): (Seq[AppendStatement], Map[String, Field]) = {
+    val producedFields = mutable.Map.newBuilder[String, Field]
+    val resolved = appends.map { append =>
+      val field = resolveField(append.field, fieldMap)
+      val as = Field(append.as, append.resultType)
+      producedFields += as.name -> as
+      AppendStatement(field, append.definition, as)
+    }
+
+    (resolved, (producedFields ++= fieldMap).result().toMap)
+  }
+
 
   private def resolveLookups(lookups: Seq[UnresolvedLookupStatement],
                              fieldMap: Map[String, Field],

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
@@ -377,7 +377,7 @@ class SQLPPGenerator extends AsterixQueryGenerator {
       case Relation.in =>
         s"$fieldExpr in [ ${filter.values.mkString(",")} ]"
       case _ =>
-        s"$fieldExpr ${filter.relation} ${filter.values.head}"
+        s"$fieldExpr ${filter.relation} ${filter.values(0)}"
     }
   }
 

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/unresolved.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/unresolved.scala
@@ -33,6 +33,7 @@ object Unresolved {
   def toUnresolved(query: Query): UnresolvedQuery =
     UnresolvedQuery(
       query.dataset,
+      query.append.map(toUnresolved(_)),
       query.lookup.map(toUnresolved(_)),
       query.filter.map(toUnresolved(_)),
       query.unnest.map(toUnresolved(_)),
@@ -41,6 +42,15 @@ object Unresolved {
       query.globalAggr.map(toUnresolved(_)),
       query.isEstimable
     )
+
+  def toUnresolved(append: AppendStatement): UnresolvedAppendStatement = {
+    UnresolvedAppendStatement(
+      append.field.name,
+      append.definition,
+      append.as.dataType,
+      append.as.name
+    )
+  }
 
   def toUnresolved(lookup: LookupStatement): UnresolvedLookupStatement =
     UnresolvedLookupStatement(
@@ -104,7 +114,6 @@ object Unresolved {
       select.limit,
       select.offset,
       select.fields.map(_.name)
-
     )
 
 
@@ -147,6 +156,7 @@ case class UnresolvedDataSetInfo(name: String,
                                  stats: Stats)
 
 case class UnresolvedQuery(dataset: String,
+                           append: Seq[UnresolvedAppendStatement] = Seq.empty,
                            lookup: Seq[UnresolvedLookupStatement] = Seq.empty,
                            filter: Seq[UnresolvedFilterStatement] = Seq.empty,
                            unnest: Seq[UnresolvedUnnestStatement] = Seq.empty,
@@ -155,6 +165,12 @@ case class UnresolvedQuery(dataset: String,
                            globalAggr: Option[UnresolvedGlobalAggregateStatement] = None,
                            estimable: Boolean = false
                           ) extends IReadQuery
+
+case class UnresolvedAppendStatement(field: String,
+                                     definition: String,
+                                     resultType: DataType.DataType,
+                                     as: String) extends Statement
+
 
 case class UnresolvedLookupStatement(sourceKeys: Seq[String],
                                      dataset: String,

--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
@@ -26,6 +26,7 @@ object QueryExeOption {
 }
 
 case class Query(dataset: String,
+                 append: Seq[AppendStatement] = Seq.empty,
                  lookup: Seq[LookupStatement] = Seq.empty,
                  filter: Seq[FilterStatement] = Seq.empty,
                  unnest: Seq[UnnestStatement] = Seq.empty,
@@ -108,6 +109,10 @@ case class UpsertRecord(dataset: String, records: JsArray) extends IWriteQuery
 case class DeleteRecord(dataset: String, filters: Seq[FilterStatement]) extends IWriteQuery
 
 trait Statement
+
+case class AppendStatement(field: Field,
+                           definition: String,
+                           as: Field) extends Statement
 
 /**
   * Augments the source data to contain more fields.

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/AQLGeneratorTest.scala
@@ -13,7 +13,7 @@ class AQLGeneratorTest extends Specification {
     "translate a simple filter by time and group by time query" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -30,7 +30,7 @@ class AQLGeneratorTest extends Specification {
     "translate a text contain filter and group by time query" in {
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -47,7 +47,7 @@ class AQLGeneratorTest extends Specification {
     "translate a geo id set filter group by time query" in {
       val filter = Seq(stateFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -66,7 +66,7 @@ class AQLGeneratorTest extends Specification {
     "translate a text contain + time + geo id set filter and group by time + spatial cube" in {
       val filter = Seq(textFilter, timeFilter, stateFilter)
       val group = GroupStatement(Seq(byHour, byState), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -84,7 +84,7 @@ class AQLGeneratorTest extends Specification {
 
     "translate a text contain + time + geo id set filter and sample tweets" in {
       val filter = Seq(textFilter, timeFilter, stateFilter)
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, None, Some(selectRecent))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, None, Some(selectRecent))
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -103,7 +103,7 @@ class AQLGeneratorTest extends Specification {
     "translate a text contain + time + geo id set filter and group by hashtags" in {
       val filter = Seq(textFilter, timeFilter, stateFilter)
       val group = GroupStatement(Seq(byTag), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq(unnestHashTag), Some(group), Some(selectTop10Tag))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq(unnestHashTag), Some(group), Some(selectTop10Tag))
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -131,7 +131,7 @@ class AQLGeneratorTest extends Specification {
     "translate a simple filter by time and group by time query max id" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrMax))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -148,7 +148,7 @@ class AQLGeneratorTest extends Specification {
     "translate a simple filter by time and group by time query min id" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrMin))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -165,7 +165,7 @@ class AQLGeneratorTest extends Specification {
     "translate a simple filter by time and group by time query sum id" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrSum))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -182,7 +182,7 @@ class AQLGeneratorTest extends Specification {
     "translate a simple filter by time and group by time query avg id" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrAvg))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -199,7 +199,7 @@ class AQLGeneratorTest extends Specification {
     "translate a text contain filter and group by geocell 10th" in {
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byGeocell10), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -216,7 +216,7 @@ class AQLGeneratorTest extends Specification {
     "translate a text contain filter and group by geocell 100th" in {
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byGeocell100), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -235,7 +235,7 @@ class AQLGeneratorTest extends Specification {
       val
       filter = Seq(textFilter)
       val group = GroupStatement(Seq(byGeocell1000), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -253,7 +253,7 @@ class AQLGeneratorTest extends Specification {
     "translate a text contain filter and group by bin" in {
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byBin), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -269,7 +269,7 @@ class AQLGeneratorTest extends Specification {
 
     "translate a group by geocell without filter" in {
       val group = GroupStatement(Seq(byGeocell1000), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -285,7 +285,7 @@ class AQLGeneratorTest extends Specification {
 
     "translate a text contain filter and select 10" in {
       val filter = Seq(textFilter)
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, None, Some(selectTop10))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, None, Some(selectTop10))
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -299,7 +299,7 @@ class AQLGeneratorTest extends Specification {
     }
     "translate group by second" in {
       val group = GroupStatement(Seq(bySecond), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -313,7 +313,7 @@ class AQLGeneratorTest extends Specification {
     }
     "translate group by minute" in {
       val group = GroupStatement(Seq(byMinute), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -328,7 +328,7 @@ class AQLGeneratorTest extends Specification {
 
     "translate group by day" in {
       val group = GroupStatement(Seq(byDay), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -343,7 +343,7 @@ class AQLGeneratorTest extends Specification {
 
     "translate group by week" in {
       val group = GroupStatement(Seq(byWeek), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -358,7 +358,7 @@ class AQLGeneratorTest extends Specification {
 
     "translate group by month" in {
       val group = GroupStatement(Seq(byMonth), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -373,7 +373,7 @@ class AQLGeneratorTest extends Specification {
 
     "translate group by year" in {
       val group = GroupStatement(Seq(byYear), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -471,7 +471,7 @@ class AQLGeneratorTest extends Specification {
       val filter = Seq(textFilter, timeFilter, stateFilter)
       val globalAggr = GlobalAggregateStatement(aggrMaxGroupBy)
       val group = GroupStatement(Seq(byTag), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq(unnestHashTag), Some(group), Some(selectTop10Tag), Some(globalAggr))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq(unnestHashTag), Some(group), Some(selectTop10Tag), Some(globalAggr))
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -526,7 +526,7 @@ class AQLGeneratorTest extends Specification {
       val selectStatement = selectPopulation
       val lookup = Seq(lookupPopulation)
       val filter = Seq(textFilter)
-      val query = new Query(TwitterDataSet, lookup, filter, Seq.empty, select = Some(selectStatement))
+      val query = new Query(TwitterDataSet, Seq.empty, lookup, filter, Seq.empty, select = Some(selectStatement))
       val result = parser.generate(query, schemaMap = Map(TwitterDataSet -> twitterSchema, populationDataSet -> populationSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -551,7 +551,7 @@ class AQLGeneratorTest extends Specification {
 
       val selectValues = Seq("*", "population", "literacy")
       val filter = Seq(textFilter)
-      val query = new Query(TwitterDataSet,
+      val query = new Query(TwitterDataSet, Seq.empty,
         lookup = Seq(lookupPopulation, lookupLiteracy),
         filter, Seq.empty,
         select = Some(selectPopulationLiteracy))
@@ -584,7 +584,7 @@ class AQLGeneratorTest extends Specification {
       val group = Some(groupPopulationSum)
       val lookup = Seq(lookupPopulation)
       val filter = Seq(textFilter)
-      val query = new Query(TwitterDataSet, lookup, filter, Seq.empty, group)
+      val query = new Query(TwitterDataSet, Seq.empty, lookup, filter, Seq.empty, group)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema, populationDataSet -> populationSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -613,7 +613,7 @@ class AQLGeneratorTest extends Specification {
     "translate a meta query" in {
       val select = Some(SelectStatement(Seq(DataSetInfo.MetaSchema.timeField), Seq(SortOrder.ASC), Int.MaxValue, 0, Seq.empty))
       val query = new Query(DataSetInfo.MetaDataDBName, select = select)
-      val result = parser.generate(query, Map(DataSetInfo.MetaDataDBName->DataSetInfo.MetaSchema))
+      val result = parser.generate(query, Map(DataSetInfo.MetaDataDBName -> DataSetInfo.MetaSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |for $t in dataset berry.meta
@@ -625,7 +625,6 @@ class AQLGeneratorTest extends Specification {
         """.stripMargin.trim
       )
     }
-
 
 
   }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParserTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParserTest.scala
@@ -21,63 +21,63 @@ class JSONParserTest extends Specification {
     }
 
     "parse the hourly count request" in {
-      val expect = Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byHour), Seq(aggrCount))), None)
+      val expect = Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byHour), Seq(aggrCount))), None)
       checkQueryOnly(hourCountJSON, twitterSchemaMap, expect)
     }
     "parse the by (state, hour) count request" in {
       val filter = Seq(stateFilter, timeFilter, textFilter)
       val group = GroupStatement(Seq(byState, byHour), Seq(aggrCount))
-      val expectQuery = Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val expectQuery = Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       checkQueryOnly(filterSelectJSON, twitterSchemaMap, expectQuery)
     }
     "parse the by topK hashtag request" in {
       val filter = Seq(stateFilter, timeFilter, textFilter)
       val group = GroupStatement(Seq(byTag), Seq(aggrCount))
-      val expectQuery = Query(TwitterDataSet, Seq.empty, filter, Seq(unnestHashTag), Some(group), Some(selectTop10Tag))
+      val expectQuery = Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq(unnestHashTag), Some(group), Some(selectTop10Tag))
       checkQueryOnly(topKHashTagJSON, twitterSchemaMap, expectQuery)
     }
     "parse the by sample tweets" in {
       val filter = Seq(stateFilter, timeFilter, textFilter)
-      val expectQuery = Query(TwitterDataSet, Seq.empty, filter, Seq.empty, None, Some(selectRecent))
+      val expectQuery = Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, None, Some(selectRecent))
       checkQueryOnly(sampleTweetJSON, twitterSchemaMap, expectQuery)
     }
     "parse the group by bin" in {
-      val expectQuery = Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byBin), Seq(aggrCount))), None)
+      val expectQuery = Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byBin), Seq(aggrCount))), None)
       checkQueryOnly(groupByBinJSON, twitterSchemaMap, expectQuery)
     }
     "parse int values " in {
-      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq(intFilter), Seq.empty, None, None)
+      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq(intFilter), Seq.empty, None, None)
       checkQueryOnly(intValuesJSON, twitterSchemaMap, expectQuery)
     }
     "parse string values " in {
-      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq(stringFilter), Seq.empty, None, None)
+      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq(stringFilter), Seq.empty, None, None)
       checkQueryOnly(stringValueJSON, twitterSchemaMap, expectQuery)
     }
     "parse long values " in {
-      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq(longFilter), Seq.empty, None, None)
+      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq(longFilter), Seq.empty, None, None)
       checkQueryOnly(longValuesJSON, twitterSchemaMap, expectQuery)
     }
     "parse double values " in {
-      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq(doubleFilter), Seq.empty, None, None)
+      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq(doubleFilter), Seq.empty, None, None)
       checkQueryOnly(doubleValuesJSON, twitterSchemaMap, expectQuery)
     }
     "parse geoCellTenth group function " in {
-      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty,
+      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty,
         Some(GroupStatement(Seq(byGeocell10), Seq(aggrCount))), None)
       checkQueryOnly(geoCell10JSON, twitterSchemaMap, expectQuery)
     }
     "parse geoCellHundredth group function " in {
-      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty,
+      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty,
         Some(GroupStatement(Seq(byGeocell100), Seq(aggrCount))), None)
       checkQueryOnly(geoCell100JSON, twitterSchemaMap, expectQuery)
     }
     "parse geoCellThousandth group function " in {
-      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty,
+      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty,
         Some(GroupStatement(Seq(byGeocell1000), Seq(aggrCount))), None)
       checkQueryOnly(geoCell1000JSON, twitterSchemaMap, expectQuery)
     }
     "parse boolean filter request" in {
-      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq(retweetFilter), Seq.empty,
+      val expectQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq(retweetFilter), Seq.empty,
         Some(GroupStatement(Seq(byUser), Seq(aggrCount))), None)
       checkQueryOnly(booleanFilterJSON, twitterSchemaMap, expectQuery)
     }
@@ -110,7 +110,7 @@ class JSONParserTest extends Specification {
       val lookup = Seq(lookupPopulation)
       val filter = Seq(textFilter)
       val selectStatement = Some(selectPopulation)
-      val expectedQuery = new Query(TwitterDataSet, lookup, filter, Seq.empty, select = selectStatement)
+      val expectedQuery = new Query(TwitterDataSet, Seq.empty, lookup, filter, Seq.empty, select = selectStatement)
       checkQueryOnly(simpleLookupFilterJSON, allSchemaMap, expectedQuery)
     }
 
@@ -118,7 +118,7 @@ class JSONParserTest extends Specification {
       val lookup = Seq(lookupPopulationMultiple)
       val filter = Seq(textFilter)
       val selectStatement = Some(selectPopulation)
-      val expectedQuery = new Query(TwitterDataSet, lookup, filter, Seq.empty, select = selectStatement)
+      val expectedQuery = new Query(TwitterDataSet, Seq.empty, lookup, filter, Seq.empty, select = selectStatement)
       checkQueryOnly(multiFieldLookupFilterJSON, allSchemaMap, expectedQuery)
     }
 
@@ -126,7 +126,7 @@ class JSONParserTest extends Specification {
       val lookup = Seq(lookupPopulation, lookupLiteracy)
       val filter = Seq(textFilter)
       val selectStatement = Some(selectPopulationLiteracy)
-      val expectedQuery = new Query(TwitterDataSet, lookup, filter, Seq.empty, select = selectStatement)
+      val expectedQuery = new Query(TwitterDataSet, Seq.empty, lookup, filter, Seq.empty, select = selectStatement)
       checkQueryOnly(multiLookupFilterJSON, allSchemaMap, expectedQuery)
     }
 
@@ -136,7 +136,7 @@ class JSONParserTest extends Specification {
       val filter = Seq(textFilter)
       val select = SelectStatement(Seq.empty, Seq.empty, 0, 0, Seq(state, count, population))
       val group = GroupStatement(Seq(byState), Seq(aggrCount), Seq(lookupPopulationByState))
-      val expectedQuery = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), select = Some(select))
+      val expectedQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), select = Some(select))
       checkQueryOnly(groupLookupJSON, allSchemaMap, expectedQuery)
     }
 
@@ -145,7 +145,7 @@ class JSONParserTest extends Specification {
       val filter = Seq(textFilter)
       val select = SelectStatement(Seq.empty, Seq.empty, 0, 0, Seq(state, count, population, literacy))
       val group = GroupStatement(Seq(byState), Seq(aggrCount), Seq(lookupPopulationByState, lookupLiteracyByState))
-      val expectedQuery = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), select = Some(select))
+      val expectedQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), select = Some(select))
       checkQueryOnly(groupMultipleLookupJSON, allSchemaMap, expectedQuery)
     }
 
@@ -154,9 +154,26 @@ class JSONParserTest extends Specification {
       val filter = Seq(textFilter)
       val lookup = Seq(lookupPopulation)
       val group = GroupStatement(Seq(byState), Seq(aggrPopulationMin), Seq(lookupLiteracyByState))
-      val query = new Query(TwitterDataSet, lookup, filter, Seq.empty, Some(group), select = Some(select))
-      val expectedQuery = new Query(TwitterDataSet, lookup, filter, Seq.empty, Some(group), select = Some(select))
+      val expectedQuery = new Query(TwitterDataSet, Seq.empty, lookup, filter, Seq.empty, Some(group), select = Some(select))
       checkQueryOnly(lookupsInOutGroupJSON, allSchemaMap, expectedQuery)
+    }
+
+    "parse a append and filter and group by time query" in {
+      val append = Seq(appendLangLen)
+      val filter = Seq(langLenFilter)
+      val group = Some(GroupStatement(Seq(byHour), Seq(aggrCount)))
+      val expectedQuery = new Query(TwitterDataSet, append, filter= filter, groups = group)
+      checkQueryOnly(appendFilterGroupbyJSON, allSchemaMap, expectedQuery)
+    }
+
+
+    "parse append with lookup inside group by state and sum" in {
+      val populationDataSet = PopulationDataStore.DatasetName
+      val populationSchema = PopulationDataStore.PopulationSchema
+      val filter = Seq(textFilter)
+      val group = GroupStatement(Seq(byState), Seq(aggrAvgLangLen), Seq(lookupPopulationByState))
+      val expectedQuery = new Query(TwitterDataSet, Seq(appendLangLen), Seq.empty, filter, Seq.empty, Some(group))
+      checkQueryOnly(appendGroupLookupJSON, allSchemaMap, expectedQuery)
     }
 
   }
@@ -207,8 +224,8 @@ class JSONParserTest extends Specification {
       val batchQueryJson = Json.obj("batch" -> JsArray(Seq(hourCountJSON, groupByBinJSON)))
       val (query, option) = parser.parse(batchQueryJson, twitterSchemaMap)
       query.size must_== 2
-      query.head must_== Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byHour), Seq(aggrCount))), None)
-      query.last must_== Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byBin), Seq(aggrCount))), None)
+      query.head must_== Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byHour), Seq(aggrCount))), None)
+      query.last must_== Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byBin), Seq(aggrCount))), None)
       option must_== QueryExeOption.NoSliceNoContinue
     }
     "parse a batch of queries contains different estimable settings" in {
@@ -217,8 +234,8 @@ class JSONParserTest extends Specification {
         groupByBinJSON.as[JsObject] + ("estimable" -> JsBoolean(false)))))
       val (query, option) = parser.parse(batchQueryJson, twitterSchemaMap)
       query.size must_== 2
-      query.head must_== Query(TwitterDataSet, groups = Some(GroupStatement(Seq(byHour), Seq(aggrCount))), isEstimable = true)
-      query.last must_== Query(TwitterDataSet, groups = Some(GroupStatement(Seq(byBin), Seq(aggrCount))), isEstimable = false)
+      query.head must_== Query(TwitterDataSet, Seq.empty, groups = Some(GroupStatement(Seq(byHour), Seq(aggrCount))), isEstimable = true)
+      query.last must_== Query(TwitterDataSet, Seq.empty, groups = Some(GroupStatement(Seq(byBin), Seq(aggrCount))), isEstimable = false)
       option must_== QueryExeOption.NoSliceNoContinue
     }
     "parse a batch of queries with option" in {
@@ -226,23 +243,23 @@ class JSONParserTest extends Specification {
       val optionJson = Json.obj(QueryExeOption.TagSliceMillis -> JsNumber(1234))
       val (query, option) = parser.parse(batchQueryJson + ("option" -> optionJson), twitterSchemaMap)
       query.size must_== 2
-      query.head must_== Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byHour), Seq(aggrCount))), None)
-      query.last must_== Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byBin), Seq(aggrCount))), None)
+      query.head must_== Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byHour), Seq(aggrCount))), None)
+      query.last must_== Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byBin), Seq(aggrCount))), None)
       option.sliceMills must_== 1234
     }
   }
 
 
-  "JSONParser getDatasets" should{
-    "parse a single dataset" in{
+  "JSONParser getDatasets" should {
+    "parse a single dataset" in {
       val datasets = parser.getDatasets(zikaJSON)
       datasets must_== Seq("twitter.ds_tweet")
     }
 
-    "parse two datasets" in{
+    "parse two datasets" in {
       val datasets = parser.getDatasets(groupLookupJSON)
       datasets must_== Seq("twitter.ds_tweet", "twitter.US_population")
     }
   }
-  
+
 }

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlannerTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlannerTest.scala
@@ -11,10 +11,10 @@ class QueryPlannerTest extends Specification {
 
   val filter = Seq(textFilter, timeFilter, stateFilter)
   val group = GroupStatement(Seq(byHour, byState), Seq(aggrCount))
-  val queryCount = Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+  val queryCount = Query(TwitterDataSet, Seq.empty,  Seq.empty, filter, Seq.empty, Some(group), None)
   val groupTag = GroupStatement(Seq(byTag), Seq(aggrCount))
-  val queryTag = new Query(TwitterDataSet, Seq.empty, filter, Seq(unnestHashTag), Some(groupTag), Some(selectTop10Tag))
-  val querySample = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, None, Some(selectRecent))
+  val queryTag = new Query(TwitterDataSet, Seq.empty,  Seq.empty, filter, Seq(unnestHashTag), Some(groupTag), Some(selectTop10Tag))
+  val querySample = new Query(TwitterDataSet, Seq.empty,  Seq.empty, filter, Seq.empty, None, Some(selectRecent))
 
   val planner = new QueryPlanner
 
@@ -31,11 +31,11 @@ class QueryPlannerTest extends Specification {
       queries.exists(_.dataset == QueryPlanner.getViewKey(TwitterDataSet, "zika")) must_== true
       queries.exists(_.dataset == QueryPlanner.getViewKey(TwitterDataSet, "virus")) must_== true
       queries.exists(_.query == zikaCreateQuery) must_== true
-      queries.exists(_.query == Query(TwitterDataSet, filter = Seq(virusFilter))) must_== true
+      queries.exists(_.query == Query(TwitterDataSet, Seq.empty,  filter = Seq(virusFilter))) must_== true
     }
     "makePlan should choose a smaller view" in {
 
-      val virusCreateQuery = Query(TwitterDataSet, filter = Seq(virusFilter))
+      val virusCreateQuery = Query(TwitterDataSet, Seq.empty,  filter = Seq(virusFilter))
       val virusStats = zikaFullStats.copy(cardinality = 500)
       val virusFullYearViewInfo = DataSetInfo("virus", Some(virusCreateQuery), twitterSchema, sourceInterval, virusStats)
       val (queries, _) = planner.makePlan(queryCount, sourceInfo, Seq(zikaFullYearViewInfo, virusFullYearViewInfo))

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
@@ -13,7 +13,7 @@ class SQLPPGeneratorTest extends Specification {
   "SQLPPGenerator generate" should {
 
     "translate a simple unnest query" in {
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq(unnestHashTag), None, Some(selectTop10))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq(unnestHashTag), None, Some(selectTop10))
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """select t.`favorite_count` as `favorite_count`,t.`geo_tag`.`countyID` as `geo_tag.countyID`,t.`user_mentions` as `user_mentions`,`unnest0` as `tag`,t.`user`.`id` as `user.id`,t.`geo_tag`.`cityID` as `geo_tag.cityID`,t.`is_retweet` as `is_retweet`,t.`text` as `text`,t.`retweet_count` as `retweet_count`,t.`in_reply_to_user` as `in_reply_to_user`,t.`id` as `id`,t.`coordinate` as `coordinate`,t.`in_reply_to_status` as `in_reply_to_status`,t.`user`.`status_count` as `user.status_count`,t.`geo_tag`.`stateID` as `geo_tag.stateID`,t.`create_at` as `create_at`,t.`lang` as `lang`,t.`hashtags` as `hashtags`
@@ -27,7 +27,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a simple filter by time and group by time query" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -42,7 +42,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a simple filter with string not match" in {
       val filter = Seq(langNotMatchFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -57,7 +57,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a simple filter with string matches" in {
       val filter = Seq(langMatchFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -71,7 +71,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a text contain filter and group by time query" in {
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -85,7 +85,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a geo id set filter group by time query" in {
       val filter = Seq(stateFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -99,7 +99,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a text contain + time + geo id set filter and group by time + spatial cube" in {
       val filter = Seq(textFilter, timeFilter, stateFilter)
       val group = GroupStatement(Seq(byHour, byState), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -112,7 +112,7 @@ class SQLPPGeneratorTest extends Specification {
 
     "translate a text contain + time + geo id set filter and sample tweets" in {
       val filter = Seq(textFilter, timeFilter, stateFilter)
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, None, Some(selectRecent))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, None, Some(selectRecent))
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -128,7 +128,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a text contain + time + geo id set filter and group by hashtags" in {
       val filter = Seq(textFilter, timeFilter, stateFilter)
       val group = GroupStatement(Seq(byTag), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq(unnestHashTag), Some(group), Some(selectTop10Tag))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq(unnestHashTag), Some(group), Some(selectTop10Tag))
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -146,7 +146,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a simple filter by time and group by time query max id" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrMax))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -160,7 +160,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a simple filter by time and group by time query min id" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrMin))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -174,7 +174,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a simple filter by time and group by time query sum id" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrSum))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -188,7 +188,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a simple filter by time and group by time query avg id" in {
       val filter = Seq(timeFilter)
       val group = GroupStatement(Seq(byHour), Seq(aggrAvg))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -202,7 +202,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a text contain filter and group by geocell 10th" in {
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byGeocell10), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -216,7 +216,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a text contain filter and group by geocell 100th" in {
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byGeocell100), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -231,7 +231,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a text contain filter and group by geocell 1000th" in {
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byGeocell1000), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -246,7 +246,7 @@ class SQLPPGeneratorTest extends Specification {
     "translate a text contain filter and group by bin" in {
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byBin), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -259,7 +259,7 @@ class SQLPPGeneratorTest extends Specification {
 
     "translate a group by geocell without filter" in {
       val group = GroupStatement(Seq(byGeocell1000), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -272,7 +272,7 @@ class SQLPPGeneratorTest extends Specification {
 
     "translate a text contain filter and select 10" in {
       val filter = Seq(textFilter)
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, None, Some(selectTop10))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, None, Some(selectTop10))
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -285,7 +285,7 @@ class SQLPPGeneratorTest extends Specification {
     }
     "translate group by second" in {
       val group = GroupStatement(Seq(bySecond), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -296,7 +296,7 @@ class SQLPPGeneratorTest extends Specification {
     }
     "translate group by minute" in {
       val group = GroupStatement(Seq(byMinute), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -308,7 +308,7 @@ class SQLPPGeneratorTest extends Specification {
 
     "translate group by day" in {
       val group = GroupStatement(Seq(byDay), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -320,7 +320,7 @@ class SQLPPGeneratorTest extends Specification {
 
     "translate group by week" in {
       val group = GroupStatement(Seq(byWeek), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -332,7 +332,7 @@ class SQLPPGeneratorTest extends Specification {
 
     "translate group by month" in {
       val group = GroupStatement(Seq(byMonth), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -344,7 +344,7 @@ class SQLPPGeneratorTest extends Specification {
 
     "translate group by year" in {
       val group = GroupStatement(Seq(byYear), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(group), None)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -418,7 +418,7 @@ class SQLPPGeneratorTest extends Specification {
       val filter = Seq(textFilter, timeFilter, stateFilter)
       val globalAggr = GlobalAggregateStatement(aggrMaxGroupBy)
       val group = GroupStatement(Seq(byTag), Seq(aggrCount))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq(unnestHashTag), Some(group), Some(selectTop10Tag), Some(globalAggr))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq(unnestHashTag), Some(group), Some(selectTop10Tag), Some(globalAggr))
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """select coll_max(
@@ -453,7 +453,7 @@ class SQLPPGeneratorTest extends Specification {
       val selectStatement = SelectStatement(Seq.empty, Seq.empty, 0, 0, Seq(AllField, population))
       val lookup = Seq(lookupPopulation)
       val filter = Seq(textFilter)
-      val query = new Query(TwitterDataSet, lookup, filter, Seq.empty, select = Some(selectStatement))
+      val query = new Query(TwitterDataSet, Seq.empty, lookup, filter, Seq.empty, select = Some(selectStatement))
       val result = parser.generate(query, schemaMap = Map(TwitterDataSet -> twitterSchema, populationDataSet -> populationSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -474,7 +474,7 @@ class SQLPPGeneratorTest extends Specification {
       val lookup = LookupStatement(Seq(geoStateID), populationDataSet, Seq(stateID), Seq(population, stateID),
         Seq(population, stateID))
       val filter = Seq(textFilter)
-      val query = new Query(TwitterDataSet, Seq(lookup), filter, Seq.empty, select = Some(selectStatement))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq(lookup), filter, Seq.empty, select = Some(selectStatement))
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema, populationDataSet -> populationSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -497,7 +497,7 @@ class SQLPPGeneratorTest extends Specification {
       val selectValues = Seq(AllField, population, literacy)
       val selectStatement = SelectStatement(Seq.empty, Seq.empty, 0, 0, selectValues)
       val filter = Seq(textFilter)
-      val query = new Query(TwitterDataSet,
+      val query = new Query(TwitterDataSet, Seq.empty,
         lookup = Seq(lookupPopulation, lookupLiteracy),
         filter, Seq.empty,
         select = Some(selectStatement))
@@ -530,7 +530,7 @@ class SQLPPGeneratorTest extends Specification {
         selectValues,
         as = selectValues)
       val filter = Seq(textFilter)
-      val query = new Query(TwitterDataSet, Seq(lookup), filter, Seq.empty, group)
+      val query = new Query(TwitterDataSet, Seq.empty, Seq(lookup), filter, Seq.empty, group)
       val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema, populationDataSet -> populationSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """select `state` as `state`,coll_sum( (select value g.l0.`population` from g) ) as `sum`
@@ -568,7 +568,7 @@ class SQLPPGeneratorTest extends Specification {
 
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byState), Seq(aggrCount), Seq(lookupPopulationByState))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group))
       val result = parser.generate(query, schemaMap = Map(TwitterDataSet -> twitterSchema, populationDataSet -> populationSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -592,7 +592,7 @@ class SQLPPGeneratorTest extends Specification {
       val selectStatement = SelectStatement(Seq.empty, Seq.empty, 0, 0, Seq(state, count, population, literacy))
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byState), Seq(aggrCount), Seq(lookupPopulationByState, lookupLiteracyByState))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), select = Some(selectStatement))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), select = Some(selectStatement))
       val result = parser.generate(query, schemaMap = Map(TwitterDataSet -> twitterSchema, populationDataSet -> populationSchema, literacyDataSet -> literacySchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -620,7 +620,7 @@ class SQLPPGeneratorTest extends Specification {
       val filter = Seq(textFilter)
       val lookup = Seq(lookupPopulation)
       val group = GroupStatement(Seq(byState), Seq(aggrPopulationMin), Seq(lookupLiteracyByState))
-      val query = new Query(TwitterDataSet, lookup, filter, Seq.empty, Some(group), select = Some(selectStatement))
+      val query = new Query(TwitterDataSet, Seq.empty, lookup, filter, Seq.empty, Some(group), select = Some(selectStatement))
       val result = parser.generate(query, schemaMap = Map(TwitterDataSet -> twitterSchema, populationDataSet -> populationSchema, literacyDataSet -> literacySchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -645,7 +645,7 @@ class SQLPPGeneratorTest extends Specification {
       val selectStatement = SelectStatement(Seq.empty, Seq.empty, 0, 0, Seq(AllField, population))
       val filter = Seq(textFilter)
       val group = GroupStatement(Seq(byState), Seq.empty, Seq(lookupPopulationByState))
-      val query = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), Some(selectStatement), Some(GlobalAggregateStatement(aggrPopulationMin)))
+      val query = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), Some(selectStatement), Some(GlobalAggregateStatement(aggrPopulationMin)))
       val result = parser.generate(query, schemaMap = Map(TwitterDataSet -> twitterSchema, populationDataSet -> populationSchema))
       removeEmptyLine(result) must_== unifyNewLine(
         """
@@ -664,6 +664,45 @@ class SQLPPGeneratorTest extends Specification {
           stripMargin.trim
       )
     }
+
+    "translate a append and filter and group by time query" in {
+      val filter = Seq(langLenFilter)
+      val group = GroupStatement(Seq(byHour), Seq(aggrCount))
+      val query = new Query(TwitterDataSet, Seq(appendLangLen), Seq.empty, filter, Seq.empty, Some(group), None)
+      val result = parser.generate(query, Map(TwitterDataSet -> twitterSchema))
+      removeEmptyLine(result) must_== unifyNewLine(
+        """
+          |select `hour` as `hour`,coll_count(g) as `count`
+          |from (select length(lang) as `lang_len`,t.`favorite_count` as `favorite_count`,t.`geo_tag`.`countyID` as `geo_tag.countyID`,t.`user_mentions` as `user_mentions`,t as `geo`,t.`user`.`id` as `user.id`,t.`geo_tag`.`cityID` as `geo_tag.cityID`,t.`is_retweet` as `is_retweet`,t.`text` as `text`,t.`retweet_count` as `retweet_count`,t.`in_reply_to_user` as `in_reply_to_user`,t.`id` as `id`,t.`coordinate` as `coordinate`,t.`in_reply_to_status` as `in_reply_to_status`,t.`user`.`status_count` as `user.status_count`,t.`geo_tag`.`stateID` as `geo_tag.stateID`,t.`create_at` as `create_at`,t.`lang` as `lang`,t.`hashtags` as `hashtags`
+          |from twitter.ds_tweet t) ta
+          |where ta.lang_len >= 1
+          |group by get_interval_start_datetime(interval_bin(ta.create_at, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour` group as g;
+          |""".stripMargin.trim)
+    }
+
+    "translate append with lookup inside group by state and sum" in {
+      val populationDataSet = PopulationDataStore.DatasetName
+      val populationSchema = PopulationDataStore.PopulationSchema
+
+      val filter = Seq(textFilter)
+      val group = GroupStatement(Seq(byState), Seq(aggrAvgLangLen), Seq(lookupPopulationByState))
+      val query = new Query(TwitterDataSet, Seq(appendLangLen), Seq.empty, filter, Seq.empty, Some(group))
+      val result = parser.generate(query, schemaMap = Map(TwitterDataSet -> twitterSchema, populationDataSet -> populationSchema))
+      removeEmptyLine(result) must_== unifyNewLine(
+        """
+          |select tt.`state` as `state`,tt.`avgLangLen` as `avgLangLen`,ll0.`population` as `population`
+          |from (
+          |select `state` as `state`,coll_avg( (select value g.ta.lang_len from g) ) as `avgLangLen`
+          |from (select length(lang) as `lang_len`,t.`favorite_count` as `favorite_count`,t.`geo_tag`.`countyID` as `geo_tag.countyID`,t.`user_mentions` as `user_mentions`,t as `geo`,t.`user`.`id` as `user.id`,t.`geo_tag`.`cityID` as `geo_tag.cityID`,t.`is_retweet` as `is_retweet`,t.`text` as `text`,t.`retweet_count` as `retweet_count`,t.`in_reply_to_user` as `in_reply_to_user`,t.`id` as `id`,t.`coordinate` as `coordinate`,t.`in_reply_to_status` as `in_reply_to_status`,t.`user`.`status_count` as `user.status_count`,t.`geo_tag`.`stateID` as `geo_tag.stateID`,t.`create_at` as `create_at`,t.`lang` as `lang`,t.`hashtags` as `hashtags`
+          |from twitter.ds_tweet t) ta
+          |where ftcontains(ta.text, ['zika','virus'], {'mode':'all'})
+          |group by ta.geo.geo_tag.stateID as `state` group as g
+          |) tt
+          |left outer join twitter.US_population ll0 on ll0.`stateID` = tt.`state`;
+          |""".stripMargin.trim
+      )
+    }
+
   }
 
 

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestDataSetInfo.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestDataSetInfo.scala
@@ -21,9 +21,9 @@ object TestDataSetInfo {
   val groupByBin = GroupStatement(Seq(byBin), Seq(aggrCount))
 
   val createQuery = new Query(dataset = TwitterDataSet, globalAggr = Some(globalAggr))
-  val berryAggrByTagQuery = new Query(TwitterDataSet, Seq.empty, filter, Seq.empty, Some(group), None)
-  val unnestQuery = new Query(TwitterDataSet, Seq.empty, filter, Seq(unnestHashTag), Some(groupByTag), Some(selectTop10Tag))
-  val groupByBinQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Some(groupByBin), None)
+  val berryAggrByTagQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq.empty, Some(group), None)
+  val unnestQuery = new Query(TwitterDataSet, Seq.empty, Seq.empty, filter, Seq(unnestHashTag), Some(groupByTag), Some(selectTop10Tag))
+  val groupByBinQuery = new Query(TwitterDataSet, groups = Some(groupByBin))
 
 
   val simpleDataSetInfo = new DataSetInfo("twitter.ds_tweet", None, Schema("tweet", Seq(createAt), Seq.empty, Seq.empty, createAt), interval, new Stats(endDateTime, endDateTime, endDateTime, 0))

--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestQuery.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestQuery.scala
@@ -39,6 +39,7 @@ object TestQuery {
   val min = Field("min", DataType.Number)
 
   val literacy = literacyField("literacy")
+  val langLen = NumberField("lang_len")
 
   val textValue = Seq("zika", "virus")
   val stateValue = Seq(37, 51, 24, 11, 10, 34, 42, 9, 44)
@@ -50,8 +51,9 @@ object TestQuery {
   val retweetFilter = FilterStatement(isRetweet, None, Relation.isTrue, Seq.empty)
   val bagFilter = FilterStatement(hashtags, None, Relation.contains, Seq(BagField("tags", DataType.String, false)))
   val pointFilter = FilterStatement(coordinate, None, Relation.inRange, Seq(Seq(0.0, 0.0), Seq(1.0, 1.0)))
-  val langMatchFilter =  FilterStatement(lang, None, Relation.matches, Seq("en"))
-  val langNotMatchFilter =  FilterStatement(lang, None, Relation.!=, Seq("en"))
+  val langMatchFilter = FilterStatement(lang, None, Relation.matches, Seq("en"))
+  val langNotMatchFilter = FilterStatement(lang, None, Relation.!=, Seq("en"))
+  val langLenFilter = FilterStatement(langLen, None, Relation.>=, Seq(1))
 
   val intValues = Seq(1)
   val stringValue = Seq("English")
@@ -110,6 +112,8 @@ object TestQuery {
   val aggrSum = AggregateStatement(id, Sum, Field.as(Sum(id), "sum"))
   val aggrAvg = AggregateStatement(id, Avg, Field.as(Avg(id), "avg"))
   val aggrPopulationMin = AggregateStatement(population, Min, Field.as(Min(population), "min"))
+  val aggrAvgLangLen = AggregateStatement(langLen, Avg, Field.as(Avg(langLen), "avgLangLen"))
+
 
   val groupPopulationSum = GroupStatement(
     bys = Seq(byState),
@@ -122,6 +126,9 @@ object TestQuery {
 
   val selectPopulation = SelectStatement(Seq.empty, Seq.empty, 0, 0, Seq(all, population))
   val selectPopulationLiteracy = SelectStatement(Seq.empty, Seq.empty, 0, 0, Seq(all, population, literacy))
+
+  val appendLangLen = AppendStatement(lang, "length(lang)", langLen)
+
 
   val lookupPopulation = LookupStatement(
     sourceKeys = Seq(geoStateID),
@@ -930,6 +937,105 @@ object TestQuery {
        |  }
        |}
     """.stripMargin)
+
+  val appendFilterGroupbyJSON = Json.parse(
+    s"""
+       |{
+       | "dataset":"twitter.ds_tweet",
+       | "append": [ {
+       |      "field":"lang",
+       |      "definition":"length(lang)",
+       |      "type":"Number",
+       |      "as":"lang_len"
+       |    }
+       | ],
+       | "filter":[
+       |    {
+       |      "field":"lang_len",
+       |      "relation":">=",
+       |      "values":[1]
+       |    }
+       |  ],
+       |  "group": {
+       |    "by": [
+       |      {
+       |        "field": "create_at",
+       |        "apply": {
+       |          "name": "interval",
+       |          "args": {
+       |              "unit": "hour"
+       |            }
+       |        },
+       |        "as": "hour"
+       |      }
+       |    ],
+       |    "aggregate": [
+       |      {
+       |        "field": "*",
+       |        "apply": {
+       |          "name" : "count"
+       |        },
+       |        "as": "count"
+       |      }
+       |    ]
+       |  }
+       |}
+    """.stripMargin)
+
+
+  val appendGroupLookupJSON = Json.parse(
+    s"""
+       |{
+       | "dataset":"twitter.ds_tweet",
+       | "append": [ {
+       |      "field":"lang",
+       |      "definition":"length(lang)",
+       |      "type":"Number",
+       |      "as":"lang_len"
+       |    }
+       | ],
+       | "filter":[
+       |    {
+       |      "field":"text",
+       |      "relation":"contains",
+       |      "values":[${textValue.map("\"" + _ + "\"").mkString(",")}]
+       |    }
+       |  ],
+       |  "group": {
+       |    "by": [
+       |      {
+       |        "field": "geo",
+       |        "apply": {
+       |          "name": "level",
+       |          "args": {
+       |            "level": "state"
+       |          }
+       |        },
+       |        "as": "state"
+       |      }
+       |    ],
+       |    "aggregate": [
+       |      {
+       |        "field": "lang_len",
+       |        "apply": {
+       |          "name" : "avg"
+       |        },
+       |        "as": "avgLangLen"
+       |      }
+       |    ],
+       |    "lookup": [
+       |    {
+       |      "joinKey":["state"],
+       |      "dataset":"twitter.US_population",
+       |      "lookupKey":["stateID"],
+       |      "select":["population"],
+       |      "as" : ["population"]
+       |    }
+       |    ]
+       |  }
+       |}
+    """.stripMargin)
+
 
   def removeEmptyLine(string: String): String = string.split("\\r?\\n").filterNot(_.trim.isEmpty).mkString("\n")
 


### PR DESCRIPTION
Now we have the "append" statement to define derived fields based on the base fields in a dataset and UDFs in the underlying database.

A sample query is as follows:
```
{
 "dataset":"twitter.ds_tweet",
 "append": [ {
      "field":"lang",
      "definition":"length(lang)",
      "type":"Number",
      "as":"lang_len"
    }
 ],
 "filter":[
    {
      "field":"lang_len",
      "relation":">=",
      "values":[1]
    }
  ]
...
}
```

Mainly extended `JSONParser` to extend Cloudberry query language, and implemented the translation in `SQLPPGenerator`.