### PR TITLE
Fix a bug of AppendField not projecting fields properly

### DIFF
--- a/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
+++ b/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGeneratorTest.scala
@@ -673,10 +673,10 @@ class SQLPPGeneratorTest extends Specification {
       removeEmptyLine(result) must_== unifyNewLine(
         """
           |select `hour` as `hour`,coll_count(g) as `count`
-          |from (select length(lang) as `lang_len`,t.`favorite_count` as `favorite_count`,t.`geo_tag`.`countyID` as `geo_tag.countyID`,t.`user_mentions` as `user_mentions`,t as `geo`,t.`user`.`id` as `user.id`,t.`geo_tag`.`cityID` as `geo_tag.cityID`,t.`is_retweet` as `is_retweet`,t.`text` as `text`,t.`retweet_count` as `retweet_count`,t.`in_reply_to_user` as `in_reply_to_user`,t.`id` as `id`,t.`coordinate` as `coordinate`,t.`in_reply_to_status` as `in_reply_to_status`,t.`user`.`status_count` as `user.status_count`,t.`geo_tag`.`stateID` as `geo_tag.stateID`,t.`create_at` as `create_at`,t.`lang` as `lang`,t.`hashtags` as `hashtags`
+          |from (select length(lang) as `lang_len`,t
           |from twitter.ds_tweet t) ta
-          |where ta.lang_len >= 1
-          |group by get_interval_start_datetime(interval_bin(ta.create_at, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour` group as g;
+          |where ta.`lang_len` >= 1
+          |group by get_interval_start_datetime(interval_bin(ta.t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  day_time_duration("PT1H") )) as `hour` group as g;
           |""".stripMargin.trim)
     }
 
@@ -692,11 +692,11 @@ class SQLPPGeneratorTest extends Specification {
         """
           |select tt.`state` as `state`,tt.`avgLangLen` as `avgLangLen`,ll0.`population` as `population`
           |from (
-          |select `state` as `state`,coll_avg( (select value g.ta.lang_len from g) ) as `avgLangLen`
-          |from (select length(lang) as `lang_len`,t.`favorite_count` as `favorite_count`,t.`geo_tag`.`countyID` as `geo_tag.countyID`,t.`user_mentions` as `user_mentions`,t as `geo`,t.`user`.`id` as `user.id`,t.`geo_tag`.`cityID` as `geo_tag.cityID`,t.`is_retweet` as `is_retweet`,t.`text` as `text`,t.`retweet_count` as `retweet_count`,t.`in_reply_to_user` as `in_reply_to_user`,t.`id` as `id`,t.`coordinate` as `coordinate`,t.`in_reply_to_status` as `in_reply_to_status`,t.`user`.`status_count` as `user.status_count`,t.`geo_tag`.`stateID` as `geo_tag.stateID`,t.`create_at` as `create_at`,t.`lang` as `lang`,t.`hashtags` as `hashtags`
+          |select `state` as `state`,coll_avg( (select value g.ta.`lang_len` from g) ) as `avgLangLen`
+          |from (select length(lang) as `lang_len`,t
           |from twitter.ds_tweet t) ta
-          |where ftcontains(ta.text, ['zika','virus'], {'mode':'all'})
-          |group by ta.geo.geo_tag.stateID as `state` group as g
+          |where ftcontains(ta.t.`text`, ['zika','virus'], {'mode':'all'})
+          |group by ta.t.geo_tag.stateID as `state` group as g
           |) tt
           |left outer join twitter.US_population ll0 on ll0.`stateID` = tt.`state`;
           |""".stripMargin.trim


### PR DESCRIPTION
Previously, when a query has `AppendField` statements, the generated SQL++ query contains a from subquery which projects all fields of the source dataset plus the append fields. E.g.,
```
{
 "dataset":"twitter.ds_tweet",
 "append": [ {
      "field":"lang",
      "definition":"length(lang)",
      "type":"Number",
      "as":"lang_len"
    }
 ],
 "filter":[
    {
      "field":"lang_len",
      "relation":">=",
      "values":[1]
    }
  ]
```
is generated as:
```
select ...
from (select length(lang) as `lang_len`,t.`favorite_count` as `favorite_count`,t.`geo_tag`.`countyID` as `geo_tag.countyID`,t.`user_mentions` as `user_mentions`,t as `geo`,t.`user`.`id` as `user.id`,t.`geo_tag`.`cityID` as `geo_tag.cityID`,t.`is_retweet` as `is_retweet`,t.`text` as `text`,
 t.`retweet_count` as `retweet_count`,t.`in_reply_to_user` as `in_reply_to_user`,t.`id` as `id`,t.`coordinate` as `coordinate`,t.`in_reply_to_status` as `in_reply_to_status`,t.`user`.`status_count` as `user.status_count`,
 t.`geo_tag`.`stateID` as `geo_tag.stateID`,t.`create_at` as `create_at`,t.`lang` as `lang`,t.`hashtags` as `hashtags`
 from twitter.ds_tweet t) ta
where ta.lang_len ...
```
However, the current SQLPPGenerator didn't calculate the projected fields correctly, which cased the query returns empty result.

To handle this, I used a much cleaner way to avoid project all fields of the source table, but instead:
```
select ...
from (select length(lang) as `lang_len`,t
          from twitter.ds_tweet t) ta
where ta.`lang_len` ... AND ta.t.`create_at`...
```