### PR TITLE
Integrate sentiment UDF with UI

### DIFF
--- a/script/ingestTwitterToLocalCluster.sh
+++ b/script/ingestTwitterToLocalCluster.sh
@@ -23,7 +23,6 @@ set -o nounset                              # Treat unset variables as an error
 host=${1:-"http://localhost:19002/aql"}
 nc=${2:-"nc1"}
 cat <<EOF | curl -XPOST --data-binary @- $host
-drop dataverse twitter if exists;
 create dataverse twitter if not exists;
 use dataverse twitter
 create type typeUser if not exists as open {

--- a/twittermap/app/controllers/TwitterMapApplication.scala
+++ b/twittermap/app/controllers/TwitterMapApplication.scala
@@ -19,10 +19,10 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
                                       val environment: Environment) extends Controller {
 
   val USCityDataPath: String = config.getString("us.city.path").getOrElse("/public/data/city.sample.json")
-  val cloudberryRegisterURL: String = config.getString("cloudberry.register").get
-  val cloudberryWS: String = config.getString("cloudberry.ws").get
-  val sentimentEnabled: Boolean = config.getBoolean("sentimentEnabled").get
-  val sentimentUDF: String = config.getString("sentimentUDF").get
+  val cloudberryRegisterURL: String = config.getString("cloudberry.register").getOrElse("http://localhost:9000/admin/register")
+  val cloudberryWS: String = config.getString("cloudberry.ws").getOrElse("ws://localhost:9000/ws")
+  val sentimentEnabled: Boolean = config.getBoolean("sentimentEnabled").getOrElse(false)
+  val sentimentUDF: String = config.getString("sentimentUDF").getOrElse("twitter.`snlp#getSentimentScore`(text)")
   val cities: List[JsValue] = TwitterMapApplication.loadCity(environment.getFile(USCityDataPath))
 
   val register = Migration_20170428.migration.up(wsClient, cloudberryRegisterURL)

--- a/twittermap/app/controllers/TwitterMapApplication.scala
+++ b/twittermap/app/controllers/TwitterMapApplication.scala
@@ -21,13 +21,14 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   val USCityDataPath: String = config.getString("us.city.path").getOrElse("/public/data/city.sample.json")
   val cloudberryRegisterURL: String = config.getString("cloudberry.register").get
   val cloudberryWS: String = config.getString("cloudberry.ws").get
+  val twitterMapSentimentAnalysisEnabled: Boolean = config.getBoolean("twitterMap.sentimentAnalysisEnabled").get
   val cities: List[JsValue] = TwitterMapApplication.loadCity(environment.getFile(USCityDataPath))
 
   val register = Migration_20170428.migration.up(wsClient, cloudberryRegisterURL)
   Await.result(register, 1 minutes)
 
   def index = Action {
-    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS))
+    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, twitterMapSentimentAnalysisEnabled))
   }
 
   def tweet(id: String) = Action.async {

--- a/twittermap/app/controllers/TwitterMapApplication.scala
+++ b/twittermap/app/controllers/TwitterMapApplication.scala
@@ -22,13 +22,14 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   val cloudberryRegisterURL: String = config.getString("cloudberry.register").get
   val cloudberryWS: String = config.getString("cloudberry.ws").get
   val sentimentEnabled: Boolean = config.getBoolean("sentimentEnabled").get
+  val sentimentUDF: String = config.getString("sentimentUDF").get
   val cities: List[JsValue] = TwitterMapApplication.loadCity(environment.getFile(USCityDataPath))
 
   val register = Migration_20170428.migration.up(wsClient, cloudberryRegisterURL)
   Await.result(register, 1 minutes)
 
   def index = Action {
-    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, sentimentEnabled))
+    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, sentimentEnabled, sentimentUDF))
   }
 
   def tweet(id: String) = Action.async {

--- a/twittermap/app/controllers/TwitterMapApplication.scala
+++ b/twittermap/app/controllers/TwitterMapApplication.scala
@@ -21,14 +21,14 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   val USCityDataPath: String = config.getString("us.city.path").getOrElse("/public/data/city.sample.json")
   val cloudberryRegisterURL: String = config.getString("cloudberry.register").get
   val cloudberryWS: String = config.getString("cloudberry.ws").get
-  val twitterMapSentimentAnalysisEnabled: Boolean = config.getBoolean("twitterMap.sentimentAnalysisEnabled").get
+  val sentimentEnabled: Boolean = config.getBoolean("sentimentEnabled").get
   val cities: List[JsValue] = TwitterMapApplication.loadCity(environment.getFile(USCityDataPath))
 
   val register = Migration_20170428.migration.up(wsClient, cloudberryRegisterURL)
   Await.result(register, 1 minutes)
 
   def index = Action {
-    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, twitterMapSentimentAnalysisEnabled))
+    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, sentimentEnabled))
   }
 
   def tweet(id: String) = Action.async {

--- a/twittermap/app/views/twittermap/index.scala.html
+++ b/twittermap/app/views/twittermap/index.scala.html
@@ -1,5 +1,5 @@
 
-@(title: String, ws: String, sentimentAnalysisEnabled: Boolean) @main(title, ws, sentimentAnalysisEnabled){
+@(title: String, ws: String, sentimentEnabled: Boolean) @main(title, ws, sentimentEnabled){
 <div xmlns="http://www.w3.org/1999/html" ng-controller="AppCtrl">
 
   <div class="map-group">

--- a/twittermap/app/views/twittermap/index.scala.html
+++ b/twittermap/app/views/twittermap/index.scala.html
@@ -1,5 +1,5 @@
 
-@(title: String, ws: String, sentimentEnabled: Boolean) @main(title, ws, sentimentEnabled){
+@(title: String, ws: String, sentimentEnabled: Boolean, sentimentUDF: String) @main(title, ws, sentimentEnabled, sentimentUDF){
 <div xmlns="http://www.w3.org/1999/html" ng-controller="AppCtrl">
 
   <div class="map-group">

--- a/twittermap/app/views/twittermap/index.scala.html
+++ b/twittermap/app/views/twittermap/index.scala.html
@@ -1,5 +1,5 @@
 
-@(title: String, ws: String) @main(title, ws){
+@(title: String, ws: String, sentimentAnalysisEnabled: Boolean) @main(title, ws, sentimentAnalysisEnabled){
 <div xmlns="http://www.w3.org/1999/html" ng-controller="AppCtrl">
 
   <div class="map-group">

--- a/twittermap/app/views/twittermap/main.scala.html
+++ b/twittermap/app/views/twittermap/main.scala.html
@@ -1,4 +1,4 @@
-@(title: String, ws: String)(body: Html)
+@(title: String, ws: String, sentimentAnalysisEnabled: Boolean)(body: Html)
 
 <!DOCTYPE html>
 <html ng-app="cloudberry">
@@ -19,7 +19,8 @@
 
   <script>
     var config= {
-      wsURL:"@ws"
+      wsURL:"@ws",
+      sentimentAnalysisEnabled: @sentimentAnalysisEnabled
     }
   </script>
   <script src='@routes.Assets.versioned("lib/angularjs/angular.min.js")'></script>

--- a/twittermap/app/views/twittermap/main.scala.html
+++ b/twittermap/app/views/twittermap/main.scala.html
@@ -1,4 +1,4 @@
-@(title: String, ws: String, sentimentAnalysisEnabled: Boolean)(body: Html)
+@(title: String, ws: String, sentimentEnabled: Boolean)(body: Html)
 
 <!DOCTYPE html>
 <html ng-app="cloudberry">
@@ -20,7 +20,7 @@
   <script>
     var config= {
       wsURL:"@ws",
-      sentimentAnalysisEnabled: @sentimentAnalysisEnabled
+      sentimentAnalysisEnabled: @sentimentEnabled
     }
   </script>
   <script src='@routes.Assets.versioned("lib/angularjs/angular.min.js")'></script>

--- a/twittermap/app/views/twittermap/main.scala.html
+++ b/twittermap/app/views/twittermap/main.scala.html
@@ -1,4 +1,4 @@
-@(title: String, ws: String, sentimentEnabled: Boolean)(body: Html)
+@(title: String, ws: String, sentimentEnabled: Boolean, sentimentUDF: String)(body: Html)
 
 <!DOCTYPE html>
 <html ng-app="cloudberry">
@@ -20,7 +20,8 @@
   <script>
     var config= {
       wsURL:"@ws",
-      sentimentEnabled: @sentimentEnabled
+      sentimentEnabled: @sentimentEnabled,
+      sentimentUDF: "@sentimentUDF"
     }
   </script>
   <script src='@routes.Assets.versioned("lib/angularjs/angular.min.js")'></script>

--- a/twittermap/app/views/twittermap/main.scala.html
+++ b/twittermap/app/views/twittermap/main.scala.html
@@ -20,7 +20,7 @@
   <script>
     var config= {
       wsURL:"@ws",
-      sentimentAnalysisEnabled: @sentimentEnabled
+      sentimentEnabled: @sentimentEnabled
     }
   </script>
   <script src='@routes.Assets.versioned("lib/angularjs/angular.min.js")'></script>

--- a/twittermap/conf/application.conf
+++ b/twittermap/conf/application.conf
@@ -79,6 +79,7 @@ bounded-mailbox {
 cloudberry.register = "http://localhost:9000/admin/register"
 cloudberry.ws = "ws://localhost:9000/ws"
 sentimentEnabled = true
+sentimentUDF = "twitter.`snlp#getSentimentScore`(text)"
 # for the debug purpose, we can load a smaller json to speed up the front-end
 us.city.path = "/public/data/city.sample.json"
 tweet.url = "http://twitterMapIndex-search-proxy.herokuapp.com/search/tweets?q=%s"

--- a/twittermap/conf/application.conf
+++ b/twittermap/conf/application.conf
@@ -75,8 +75,10 @@ bounded-mailbox {
   mailbox-push-timeout-time = 10s
 }
 
-# for the debug purpose, we can load a smaller json to speed up the front-end
+
 cloudberry.register = "http://localhost:9000/admin/register"
 cloudberry.ws = "ws://localhost:9000/ws"
+twitterMap.sentimentAnalysisEnabled = true
+# for the debug purpose, we can load a smaller json to speed up the front-end
 us.city.path = "/public/data/city.sample.json"
 tweet.url = "http://twitterMapIndex-search-proxy.herokuapp.com/search/tweets?q=%s"

--- a/twittermap/conf/application.conf
+++ b/twittermap/conf/application.conf
@@ -78,7 +78,7 @@ bounded-mailbox {
 
 cloudberry.register = "http://localhost:9000/admin/register"
 cloudberry.ws = "ws://localhost:9000/ws"
-twitterMap.sentimentAnalysisEnabled = true
+sentimentEnabled = true
 # for the debug purpose, we can load a smaller json to speed up the front-end
 us.city.path = "/public/data/city.sample.json"
 tweet.url = "http://twitterMapIndex-search-proxy.herokuapp.com/search/tweets?q=%s"

--- a/twittermap/public/javascripts/common/services.js
+++ b/twittermap/public/javascripts/common/services.js
@@ -3,6 +3,7 @@ angular.module('cloudberry.common', [])
     return {
       ws: config.wsURL,
       sentimentEnabled: config.sentimentEnabled,
+      sentimentUDF: config.sentimentUDF,
       normalizationUpscaleFactor: 1000 * 1000,
       normalizationUpscaleText: "/M",
       sentimentUpperBound: 4,
@@ -117,7 +118,7 @@ angular.module('cloudberry.common', [])
           dataset: parameters.dataset,
           append: [{
             field: "text",
-            definition: "twitter.`snlp#getSentimentScore`(text)",
+            definition: cloudberryConfig.sentimentUDF,
             type: "Number",
             as: "sentimentScore"
           }],

--- a/twittermap/public/javascripts/common/services.js
+++ b/twittermap/public/javascripts/common/services.js
@@ -2,7 +2,7 @@ angular.module('cloudberry.common', [])
   .factory('cloudberryConfig', function(){
     return {
       ws: config.wsURL,
-      sentimentAnalysisEnabled: true,
+      sentimentAnalysisEnabled: config.sentimentAnalysisEnabled,
       normalizationUpscaleFactor: 1000 * 1000,
       normalizationUpscaleText: "/M",
       sentimentUpperBound: 4,

--- a/twittermap/public/javascripts/common/services.js
+++ b/twittermap/public/javascripts/common/services.js
@@ -112,7 +112,7 @@ angular.module('cloudberry.common', [])
     }
 
     function byGeoRequest(parameters) {
-      if(cloudberryConfig.sentimentAnalysisEnabled) {
+      if (cloudberryConfig.sentimentAnalysisEnabled) {
         return {
           dataset: parameters.dataset,
           append: [{
@@ -139,7 +139,7 @@ angular.module('cloudberry.common', [])
                 name: "count"
               },
               as: "count"
-            },{
+            }, {
               field: "sentimentScore",
               apply: {
                 name: "sum"
@@ -157,7 +157,7 @@ angular.module('cloudberry.common', [])
             ]
           }
         };
-      } else{
+      } else {
         return {
           dataset: parameters.dataset,
           filter: getFilter(parameters, defaultNonSamplingDayRange),
@@ -184,6 +184,7 @@ angular.module('cloudberry.common', [])
             ]
           }
         };
+      }
     }
 
     function byTimeRequest(parameters) {

--- a/twittermap/public/javascripts/common/services.js
+++ b/twittermap/public/javascripts/common/services.js
@@ -111,10 +111,8 @@ angular.module('cloudberry.common', [])
       ];
     }
 
-
-
     function byGeoRequest(parameters) {
-      if(cloudberryConfig.sentimentAnalysisEnabled)
+      if(cloudberryConfig.sentimentAnalysisEnabled) {
         return {
           dataset: parameters.dataset,
           append: [{
@@ -159,7 +157,7 @@ angular.module('cloudberry.common', [])
             ]
           }
         };
-      else
+      } else{
         return {
           dataset: parameters.dataset,
           filter: getFilter(parameters, defaultNonSamplingDayRange),

--- a/twittermap/public/javascripts/common/services.js
+++ b/twittermap/public/javascripts/common/services.js
@@ -2,7 +2,7 @@ angular.module('cloudberry.common', [])
   .factory('cloudberryConfig', function(){
     return {
       ws: config.wsURL,
-      sentimentAnalysisEnabled: config.sentimentAnalysisEnabled,
+      sentimentEnabled: config.sentimentEnabled,
       normalizationUpscaleFactor: 1000 * 1000,
       normalizationUpscaleText: "/M",
       sentimentUpperBound: 4,
@@ -112,7 +112,7 @@ angular.module('cloudberry.common', [])
     }
 
     function byGeoRequest(parameters) {
-      if (cloudberryConfig.sentimentAnalysisEnabled) {
+      if (cloudberryConfig.sentimentEnabled) {
         return {
           dataset: parameters.dataset,
           append: [{

--- a/twittermap/public/javascripts/common/services.js
+++ b/twittermap/public/javascripts/common/services.js
@@ -2,7 +2,7 @@ angular.module('cloudberry.common', [])
   .factory('cloudberryConfig', function(){
     return {
       ws: config.wsURL,
-      sentimentAnalysisEnabled: false,
+      sentimentAnalysisEnabled: true,
       normalizationUpscaleFactor: 1000 * 1000,
       normalizationUpscaleText: "/M",
       sentimentUpperBound: 4,

--- a/twittermap/public/javascripts/map/controllers.js
+++ b/twittermap/public/javascripts/map/controllers.js
@@ -483,8 +483,8 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
             angular.forEach(result, function (r) {
               if (r[level] === geo['properties'][level+"ID"]){
                 if($scope.doSentiment){
-                  // TODO: change fake random number to real sentiment (0-4)
-                  geo['properties']['count'] = Math.random() * 4;
+                  // sentimentScore for all the tweets in the same polygon / number of tweets with the score
+                  geo['properties']['count'] = r['sentimentScoreSum'] / r['sentimentScoreCount'];
                   geo["properties"]["countText"] = geo["properties"]["count"].toFixed(1);
                 } else if ($scope.doNormalization) {
                   setNormalizedCount(geo, r);
@@ -632,7 +632,8 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
       addMapControl('normalize', 'topleft', initNormalize, initNormalizeToggle);
 
       // add toggle sentiment analysis
-      addMapControl('sentiment', 'topleft', initSentiment, initSentimentToggle);
+      if(cloudberryConfig.sentimentAnalysisEnabled)
+        addMapControl('sentiment', 'topleft', initSentiment, initSentimentToggle);
 
     }
 

--- a/twittermap/public/javascripts/map/controllers.js
+++ b/twittermap/public/javascripts/map/controllers.js
@@ -633,7 +633,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
       addMapControl('normalize', 'topleft', initNormalize, initNormalizeToggle);
 
       // add toggle sentiment analysis
-      if(cloudberryConfig.sentimentAnalysisEnabled)
+      if(cloudberryConfig.sentimentEnabled)
         addMapControl('sentiment', 'topleft', initSentiment, initSentimentToggle);
 
     }

--- a/twittermap/public/javascripts/map/controllers.js
+++ b/twittermap/public/javascripts/map/controllers.js
@@ -3,6 +3,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
     $scope.result = {};
     $scope.doNormalization = false;
     $scope.doSentiment = false;
+    $scope.infoPromp = "Count";
     // map setting
     angular.extend($scope, {
       tiles: {
@@ -171,10 +172,10 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
         this._div = L.DomUtil.create('div', 'info'); // create a div with a class "info"
         this._div.style.margin = '20% 0 0 0';
         this._div.innerHTML = [
-          '<h4>Count by {{ status.logicLevel }}</h4>',
+          '<h4>{{ infoPromp }} by {{ status.logicLevel }}</h4>',
           '<b>{{ selectedPlace.properties.name || "No place selected" }}</b>',
           '<br/>',
-          'Count: {{ selectedPlace.properties.countText || "0" }}'
+          '{{ infoPromp }}: {{ selectedPlace.properties.countText || "0" }}'
         ].join('');
         $compile(this._div)($scope);
         return this._div;
@@ -666,6 +667,10 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
         }
         if(newResult['doSentiment'] !== oldValue['doSentiment']) {
           $scope.doSentiment = newResult['doSentiment'];
+          if($scope.doSentiment)
+            $scope.infoPromp = "Score";  // change the info promp
+          else
+            $scope.infoPromp = "Count";
           drawMap($scope.result);
         }
       }

--- a/twittermap/public/javascripts/map/controllers.js
+++ b/twittermap/public/javascripts/map/controllers.js
@@ -667,10 +667,11 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common'])
         }
         if(newResult['doSentiment'] !== oldValue['doSentiment']) {
           $scope.doSentiment = newResult['doSentiment'];
-          if($scope.doSentiment)
+          if($scope.doSentiment) {
             $scope.infoPromp = "Score";  // change the info promp
-          else
+          } else {
             $scope.infoPromp = "Count";
+          }
           drawMap($scope.result);
         }
       }


### PR DESCRIPTION
Change:
- TwitterMap now shows the real sentiment analysis. 
- Sentiment Analysis is now optional. It can be removed by setting `cloudberryConfig.sentimentAnalysisEnabled` to `false`

Method:
- Use `append` before `groupBy` to add a sentiment score based on the `text` field on each record
- aggregate by summing and counting`sentimentScore` 
- The results that are shown on the TwitterMap = sum / count

**NOTE:**
- This PR uses ```twitter.`snlp#getSentimentScore`(text)``` as this is the only UDF available in the docker image

![screen shot 2017-05-06 at 15 54 02](https://cloud.githubusercontent.com/assets/12385178/25776524/824e70ba-3275-11e7-8642-00bf35947ce4.jpg)
![screen shot 2017-05-06 at 15 54 20](https://cloud.githubusercontent.com/assets/12385178/25776525/82520ad6-3275-11e7-9400-5ae1f34d35bd.jpg)
![screen shot 2017-05-06 at 15 54 55](https://cloud.githubusercontent.com/assets/12385178/25776523/824a34a0-3275-11e7-90b8-58b2a6cf852c.jpg)

# new information prompt for score (Notice it is "Score" rather than "Count" in the top left corner)
## when sentimentAnalysis is ON
![screen shot 2017-05-06 at 16 19 02](https://cloud.githubusercontent.com/assets/12385178/25776616/ff9d76c2-3277-11e7-8927-28bc7fe70677.jpg)
## when sentimentAnalysis is OFF
![screen shot 2017-05-06 at 16 19 26](https://cloud.githubusercontent.com/assets/12385178/25776617/ffb4b6ac-3277-11e7-9e5a-de01736f730d.jpg)

## After turning off sentimentAnalysis in the application.config
![screen shot 2017-05-06 at 21 30 49](https://cloud.githubusercontent.com/assets/12385178/25777935/ccc621dc-32a3-11e7-88ae-df6717375213.jpg)

