### PR TITLE
Change the order of append to be after filter

### DIFF
--- a/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
+++ b/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/SQLPPGenerator.scala
@@ -122,16 +122,16 @@ class SQLPPGenerator extends AsterixQueryGenerator {
     val fromStr = s"from ${query.dataset} $sourceVar".trim
     queryBuilder.append(fromStr)
 
-    val resultAfterAppend = parseAppend(query.append, exprMap, queryBuilder)
-
-    val resultAfterLookup = parseLookup(query.lookup, resultAfterAppend.exprMap, queryBuilder, false)
+    val resultAfterLookup = parseLookup(query.lookup, exprMap, queryBuilder, false)
 
     val resultAfterUnnest = parseUnnest(query.unnest, resultAfterLookup.exprMap, queryBuilder)
     val unnestTests = resultAfterUnnest.strs
 
     val resultAfterFilter = parseFilter(query.filter, resultAfterUnnest.exprMap, unnestTests, queryBuilder)
 
-    val resultAfterGroup = parseGroupby(query.groups, resultAfterFilter.exprMap, queryBuilder)
+    val resultAfterAppend = parseAppend(query.append, resultAfterFilter.exprMap, queryBuilder)
+
+    val resultAfterGroup = parseGroupby(query.groups, resultAfterAppend.exprMap, queryBuilder)
 
     val resultAfterSelect = parseSelect(query.select, resultAfterGroup.exprMap, query, queryBuilder)
 


### PR DESCRIPTION
Currently `append` statement is executed first in the SQLPPGenerator, which causes the query execution very slow (because AsterixDB couldn't figure out the proper optimization by itself...).

Now `append` statement would be executed after filter statement.

For example,
```
{
 "dataset":"twitter.ds_tweet",
 "append": [ {
      "field":"lang",
      "definition":"length(lang)",
      "type":"Number",
      "as":"lang_len"
    }
 ],
 "filter":[
    {
      "field":"create_at",
...
    }
  ]
```
previously is generated as:
```
select ...
from (select length(lang) as `lang_len`,t
          from twitter.ds_tweet t) ta
where ta.`lang_len` ... AND ta.t.`create_at`...
```

But after this change, the result query looks like:
```
select ...
from (select length(lang) as `lang_len`,t
          from twitter.ds_tweet t
          where t.`create_at`...) ta
group by ...
```