### PR TITLE
Disable the sentiment by default

### DIFF
--- a/twittermap/conf/application.conf
+++ b/twittermap/conf/application.conf
@@ -78,7 +78,7 @@ bounded-mailbox {
 
 cloudberry.register = "http://localhost:9000/admin/register"
 cloudberry.ws = "ws://localhost:9000/ws"
-sentimentEnabled = true
+sentimentEnabled = false
 sentimentUDF = "twitter.`snlp#getSentimentScore`(text)"
 # for the debug purpose, we can load a smaller json to speed up the front-end
 us.city.path = "/public/data/city.sample.json"


### PR DESCRIPTION
We can not assume Cloudberry users has the sentiment library. So we will disable it by default.