### PR TITLE
[#ISSUE 347] Fixed bug of multi-keywords

### DIFF
--- a/twittermap/public/javascripts/common/services.js
+++ b/twittermap/public/javascripts/common/services.js
@@ -107,7 +107,7 @@ angular.module('cloudberry.common', [])
         }, {
           field: "text",
           relation: "contains",
-          values: [mkString(keywords, ",")]
+          values: keywords,
         }
       ];
     }


### PR DESCRIPTION
Fixed the bug that TwitterMap didn't show correctly in case of multi-keywords.

It turns out that it's a bug of the front end. For example, when search "happy new year", the front-end would send a query like this:
```
{"field":"text",
  "relation":"contains",
   "values":["happy,new,year"]
}
```
The three keywords here are just one single object, and thus treated as a single keyword by the backend.

The correct way sending query should be:
```
{"field":"text",
  "relation":"contains",
   "values":["happy","new","year"]
}
```