### PR TITLE
[Issue #280] Log client information in Twittermap demo

### DIFF
--- a/neo/app/actor/RequestRouter.scala
+++ b/neo/app/actor/RequestRouter.scala
@@ -5,19 +5,26 @@ import akka.stream.Materializer
 import edu.uci.ics.cloudberry.zion.actor.BerryClient._
 import edu.uci.ics.cloudberry.zion.common.Config
 import play.api.libs.json._
+import play.api.Logger
+import play.api.mvc.RequestHeader
 
 import scala.concurrent.ExecutionContext
 
-class RequestRouter (berryClientProp: Props, config: Config)
+class RequestRouter (berryClientProp: Props, config: Config, requestHeader: RequestHeader)
                     (implicit ec: ExecutionContext, implicit val materializer: Materializer) extends Actor with ActorLogging {
 
   import RequestRouter._
 
   val streamingBerryClient = context.actorOf(berryClientProp, streamingClientName)
   val nonStreamingBerryClient = context.actorOf(berryClientProp, nonStreamingClientName)
+  val clientLogger = Logger("client")
 
   override def receive: Receive = {
     case requestBody: JsValue =>
+      val remoteAddress = requestHeader.remoteAddress
+      val userAgent = requestHeader.headers.get("user-agent").getOrElse("unknown")
+      clientLogger.info(s"user-IP = $remoteAddress; user-agent = $userAgent; user-query = ${requestBody.toString}")
+
       val transformer = parseTransform(requestBody)
       val berryRequestBody = getBerryRequest(requestBody)
       (berryRequestBody \\ "sliceMillis").isEmpty match {
@@ -60,8 +67,8 @@ object RequestRouter {
   val streamingClientName = "streamingClient"
   val nonStreamingClientName = "nonStreamingClient"
 
-  def props(berryClientProp: Props, config: Config)
-           (implicit ec: ExecutionContext, materializer: Materializer) = Props(new RequestRouter(berryClientProp, config))
+  def props(berryClientProp: Props, config: Config, requestHeader: RequestHeader)
+           (implicit ec: ExecutionContext, materializer: Materializer) = Props(new RequestRouter(berryClientProp, config, requestHeader))
 
   case class WrapTransform(key: String) extends IPostTransform {
     override def transform(jsonBody: JsValue): JsValue = {

--- a/neo/app/actor/RequestRouter.scala
+++ b/neo/app/actor/RequestRouter.scala
@@ -23,7 +23,7 @@ class RequestRouter (berryClientProp: Props, config: Config, requestHeader: Requ
     case requestBody: JsValue =>
       val remoteAddress = requestHeader.remoteAddress
       val userAgent = requestHeader.headers.get("user-agent").getOrElse("unknown")
-      clientLogger.info(s"user-IP = $remoteAddress; user-agent = $userAgent; user-query = ${requestBody.toString}")
+      clientLogger.info(s"Request: user-IP = $remoteAddress; user-agent = $userAgent; user-query = ${requestBody.toString}")
 
       val transformer = parseTransform(requestBody)
       val berryRequestBody = getBerryRequest(requestBody)

--- a/neo/app/controllers/Cloudberry.scala
+++ b/neo/app/controllers/Cloudberry.scala
@@ -81,7 +81,7 @@ class Cloudberry @Inject()(val wsClient: WSClient,
 
   def ws = WebSocket.accept[JsValue, JsValue] { request =>
     ActorFlow.actorRef { out =>
-      RequestRouter.props(BerryClient.props(new JSONParser(), manager, new QueryPlanner(), config, out), config)
+      RequestRouter.props(BerryClient.props(new JSONParser(), manager, new QueryPlanner(), config, out), config, request)
     }
   }
 

--- a/neo/conf/logback.xml
+++ b/neo/conf/logback.xml
@@ -18,6 +18,17 @@
     </encoder>
   </appender>
 
+  <appender name="CLIENT_FILE" class="ch.qos.logback.core.FileAppender">
+    <file>logs/client.log</file>
+    <encoder>
+      <pattern>%date [%level] - %message%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- additivity=false ensures client log data only goes to the client log -->
+  <logger name="client" level="INFO" additivity="false">
+    <appender-ref ref="CLIENT_FILE" />
+  </logger>
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
 

--- a/twittermap/app/controllers/TwitterMapApplication.scala
+++ b/twittermap/app/controllers/TwitterMapApplication.scala
@@ -33,7 +33,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   def index = Action { request =>
     val remoteAddress = request.remoteAddress
     val userAgent = request.headers.get("user-agent").getOrElse("unknown")
-    clientLogger.info(s"user_IP_address:=$remoteAddress; user_agent=$userAgent")
+    clientLogger.info(s"Connected: user_IP_address = $remoteAddress; user_agent = $userAgent")
     Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, sentimentEnabled, sentimentUDF))
   }
 

--- a/twittermap/app/controllers/TwitterMapApplication.scala
+++ b/twittermap/app/controllers/TwitterMapApplication.scala
@@ -8,8 +8,7 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.{JsValue, Json, _}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
-import play.api.{Configuration, Environment}
-import play.Logger
+import play.api.{Configuration, Environment, Logger}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -26,14 +25,16 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   val sentimentUDF: String = config.getString("sentimentUDF").getOrElse("twitter.`snlp#getSentimentScore`(text)")
   val cities: List[JsValue] = TwitterMapApplication.loadCity(environment.getFile(USCityDataPath))
 
+  val clientLogger = Logger("client")
+
   val register = Migration_20170428.migration.up(wsClient, cloudberryRegisterURL)
   Await.result(register, 1 minutes)
 
   def index = Action { request =>
     val remoteAddress = request.remoteAddress
     val userAgent = request.headers.get("user-agent").getOrElse("unknown")
-    Logger.info("user IP address: " + remoteAddress)
-    Logger.info("user agent: " + userAgent)
+    clientLogger.info("user IP address: " + remoteAddress)
+    clientLogger.info("user agent: " + userAgent)
     Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, sentimentEnabled, sentimentUDF))
   }
 

--- a/twittermap/app/controllers/TwitterMapApplication.scala
+++ b/twittermap/app/controllers/TwitterMapApplication.scala
@@ -9,6 +9,7 @@ import play.api.libs.json.{JsValue, Json, _}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import play.api.{Configuration, Environment}
+import play.Logger
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -28,7 +29,12 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   val register = Migration_20170428.migration.up(wsClient, cloudberryRegisterURL)
   Await.result(register, 1 minutes)
 
-  def index = Action {
+  def index = Action { request =>
+    val remoteAddress = request.remoteAddress
+    val userAgent = request.headers.get("user-agent").getOrElse("unknown")
+    Logger.info("user IP address: " + remoteAddress)
+    Logger.info("user agent: " + userAgent)
+
     Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, sentimentEnabled, sentimentUDF))
   }
 

--- a/twittermap/app/controllers/TwitterMapApplication.scala
+++ b/twittermap/app/controllers/TwitterMapApplication.scala
@@ -33,8 +33,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   def index = Action { request =>
     val remoteAddress = request.remoteAddress
     val userAgent = request.headers.get("user-agent").getOrElse("unknown")
-    clientLogger.info("user IP address: " + remoteAddress)
-    clientLogger.info("user agent: " + userAgent)
+    clientLogger.info(s"user_IP_address:=$remoteAddress; user_agent=$userAgent")
     Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, sentimentEnabled, sentimentUDF))
   }
 

--- a/twittermap/app/controllers/TwitterMapApplication.scala
+++ b/twittermap/app/controllers/TwitterMapApplication.scala
@@ -34,7 +34,6 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
     val userAgent = request.headers.get("user-agent").getOrElse("unknown")
     Logger.info("user IP address: " + remoteAddress)
     Logger.info("user agent: " + userAgent)
-
     Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, sentimentEnabled, sentimentUDF))
   }
 

--- a/twittermap/conf/logback.xml
+++ b/twittermap/conf/logback.xml
@@ -21,7 +21,7 @@
   <appender name="CLIENT_FILE" class="ch.qos.logback.core.FileAppender">
     <file>logs/client.log</file>
     <encoder>
-      <pattern>%date [%level] from %logger in %thread - %message%n</pattern>
+      <pattern>%date [%level] - %message%n</pattern>
     </encoder>
   </appender>
 

--- a/twittermap/conf/logback.xml
+++ b/twittermap/conf/logback.xml
@@ -18,6 +18,17 @@
     </encoder>
   </appender>
 
+  <appender name="CLIENT_FILE" class="ch.qos.logback.core.FileAppender">
+    <file>logs/client.log</file>
+    <encoder>
+      <pattern>%date [%level] from %logger in %thread - %message%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="client" level="INFO">
+    <appender-ref ref="CLIENT_FILE" />
+  </logger>
+
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
 


### PR DESCRIPTION
PR related to #280 

**Detail**
- This PR enables the tracking of client IP address and user agent when user is connected to Twittermap demo. Access information will be logged in Twittermap console and `./logs/client.log`.
- When a query was issued by user, users' identity (IP address, user agent) and the request json will be **only** logged in `./logs/client.log`.
- Other system logs are appended in `./logs/application.log`