### PR TITLE
Recover the ignored gz file

### DIFF
--- a/cloudberry/project/dependencies.scala
+++ b/cloudberry/project/dependencies.scala
@@ -26,8 +26,8 @@ object Dependencies {
   val zionDependencies: Seq[ModuleID] = Seq(
     "joda-time" % "joda-time" % "2.9.3",
     "com.typesafe.akka" %% "akka-actor" % "2.4.4",
-    "org.apache.spark" % "spark-core_2.11" % "2.1.0",
-    "org.apache.spark" % "spark-sql_2.11" % "2.1.0",
+    "org.apache.spark" % "spark-core_2.11" % "2.1.0" exclude("org.slf4j", "slf4j-log4j12"),
+    "org.apache.spark" % "spark-sql_2.11" % "2.1.0" exclude("org.slf4j", "slf4j-log4j12"),
     ("com.typesafe.play" %% "play-json" % playVersion).exclude("commons-logging", "commons-logging"),
     "com.typesafe.play" %% "play-ws" % playVersion
   ) ++ testDeps

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -51,6 +51,7 @@ If you want to shutdown the docker container later, you can use the following co
 **Step 4**: Compile and run the Cloudberry server.
 
 ```
+~/cloudberry> cd cloudberry
 ~/cloudberry> sbt compile
 ~/cloudberry> sbt "project neo" "run"
 ```
@@ -61,7 +62,7 @@ Wait until the shell prints the messages shown in the following screenshot:
 **Step 5**: Open another terminal window to ingest sample tweets (about 47K) and US population data into AsterixDB.
 
 ```
-~> cd examples/twittermap
+~/cloudberry> cd ../examples/twittermap
 ~/twittermap> ./script/ingestAllTwitterToLocalCluster.sh
 ```
 

--- a/examples/twittermap/.gitignore
+++ b/examples/twittermap/.gitignore
@@ -19,7 +19,6 @@ dist
 /project/*-shim.sbt
 /activator-sbt-*-shim.sbt
 *.iml
-*.gz
 OutputFolderPromedmail/
 .DS_Store
 .cache-main


### PR DESCRIPTION
The `sample.twitter.gz` file is ignored by git which caused the online quick-start doesn't work. 
This PR recovery the file back.