### PR TITLE
Make endDate configurable

### DIFF
--- a/examples/twittermap/web/app/controllers/TwitterMapApplication.scala
+++ b/examples/twittermap/web/app/controllers/TwitterMapApplication.scala
@@ -27,6 +27,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   val removeSearchBar: Boolean = config.getBoolean("removeSearchBar").getOrElse(false)
   val predefinedKeywords: Seq[String] = config.getStringSeq("predefinedKeywords").getOrElse(Seq())
   val startDate: String = config.getString("startDate").getOrElse("2015-11-22T00:00:00.000")
+  val endDate : Option[String] = config.getString("endDate")
   val cities: List[JsValue] = TwitterMapApplication.loadCity(environment.getFile(USCityDataPath))
 
   val clientLogger = Logger("client")
@@ -38,7 +39,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
     val remoteAddress = request.remoteAddress
     val userAgent = request.headers.get("user-agent").getOrElse("unknown")
     clientLogger.info(s"Connected: user_IP_address = $remoteAddress; user_agent = $userAgent")
-    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, startDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, false))
+    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, false))
   }
 
   def drugmap = Action {
@@ -47,7 +48,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
       val remoteAddress = request.remoteAddress
       val userAgent = request.headers.get("user-agent").getOrElse("unknown")
       clientLogger.info(s"Connected: user_IP_address = $remoteAddress; user_agent = $userAgent")
-      Ok(views.html.twittermap.index("DrugMap", cloudberryWS, startDateDrugMap, false, sentimentUDF, true, Seq("drug"), true))
+      Ok(views.html.twittermap.index("DrugMap", cloudberryWS, startDateDrugMap, endDate, false, sentimentUDF, true, Seq("drug"), true))
   }
 
   def tweet(id: String) = Action.async {

--- a/examples/twittermap/web/app/views/twittermap/index.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/index.scala.html
@@ -1,5 +1,5 @@
 
-@(title: String, ws: String, startDate: String, sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], isDrugMap: Boolean) @main(title, ws, startDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, isDrugMap){
+@(title: String, ws: String, startDate: String, endDate:Option[String], sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], isDrugMap: Boolean) @main(title, ws, startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, isDrugMap){
 <div xmlns="http://www.w3.org/1999/html" ng-controller="AppCtrl">
 
   <div class="map-group">

--- a/examples/twittermap/web/app/views/twittermap/main.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/main.scala.html
@@ -1,4 +1,4 @@
-@(title: String, ws: String, startDate: String, sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], isDrugMap: Boolean)(body: Html)
+@(title: String, ws: String, startDate: String, endDate: Option[String], sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], isDrugMap: Boolean)(body: Html)
 
 @import play.api.libs.json.Json
 
@@ -25,6 +25,9 @@
       sentimentEnabled: @sentimentEnabled,
       sentimentUDF: "@sentimentUDF",
       startDate: new Date("@startDate"),
+      @if(endDate.isDefined) {
+        endDate: new Date("@endDate.get"),
+      }
       @if(isDrugMap) {
         mapLegend: "$",
         sumText : "dollars",

--- a/examples/twittermap/web/conf/application.conf
+++ b/examples/twittermap/web/conf/application.conf
@@ -89,6 +89,8 @@ removeSearchBar = false
 predefinedKeywords = ["Diabetes", "Sleep Disorder"]
 startDate = "2015-11-22T00:00:00.000"
 
+# Set the endDate if the data is stopped feeding
+# endDate = "2017-06-20T00:00:00.000"
 
 # for the debug purpose, we can load a smaller json to speed up the front-end
 us.city.path = "/public/data/city.sample.json"

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -41,6 +41,7 @@ angular.module('cloudberry.common', [])
   })
   .service('cloudberry', function($http, $timeout, $location, cloudberryConfig) {
     var startDate = config.startDate;
+    var endDate = config.endDate;
     var defaultNonSamplingDayRange = 1500;
     var defaultSamplingDayRange = 1;
     var defaultSamplingSize = 10;
@@ -244,7 +245,7 @@ angular.module('cloudberry.common', [])
         keywords: [],
         timeInterval: {
           start: startDate,
-          end: new Date()
+          end: endDate ?  endDate : new Date()
         },
         timeBin : "day",
         geoLevel: "state",


### PR DESCRIPTION
Sometimes we need a fixed ending date to start slicing the query. It will be useful for the backup service and also for the case once we stop the online feed.