### PR TITLE
Deyu chen websocket

### DIFF
--- a/cloudberry/neo/conf/application.conf
+++ b/cloudberry/neo/conf/application.conf
@@ -93,3 +93,5 @@ asterixdb.url = "http://localhost:19002/query/service"
 asterixdb.lang = SQLPP
 #asterixdb.lang = sparksql
 asterixdb.view.meta.name = "viewMeta"
+
+play.websocket.buffer.limit = 5M

--- a/cloudberry/neo/conf/application.conf
+++ b/cloudberry/neo/conf/application.conf
@@ -94,4 +94,10 @@ asterixdb.lang = SQLPP
 #asterixdb.lang = sparksql
 asterixdb.view.meta.name = "viewMeta"
 
+# WebSocket message size limit
+# ~~~~~
+# It is possible for the frontend to send very large queries to the Cloudberry.
+# For example, when the resolution is extremely high in the TwitterMap,
+# the frontend may send queries that contain a lot of cityIDs where the size
+# can easily exceed the default message size limit of 65536 bytes.
 play.websocket.buffer.limit = 5M

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -90,12 +90,8 @@ angular.module('cloudberry.common', [])
       queryStartDate.setDate(queryStartDate.getDate() - maxDay);
       queryStartDate = parameters.timeInterval.start > queryStartDate ? parameters.timeInterval.start : queryStartDate;
 
-      return [
+      var filter = [
         {
-          field: "geo_tag." + spatialField,
-          relation: "in",
-          values: parameters.geoIds
-        }, {
           field: "create_at",
           relation: "inRange",
           values: [queryStartDate.toISOString(), parameters.timeInterval.end.toISOString()]
@@ -105,6 +101,16 @@ angular.module('cloudberry.common', [])
           values: keywords
         }
       ];
+      if (parameters.geoIds.length <= 2000){
+        filter.push(
+          {
+            field: "geo_tag." + spatialField,
+            relation: "in",
+            values: parameters.geoIds
+          }
+        );
+      }
+      return filter;
     }
 
     function byGeoRequest(parameters) {


### PR DESCRIPTION
Drop geoIds filter when the length of the geoIds is longer than 2000 to avoid large queries.