### PR TITLE
Can set the cache threshold in the config.

### DIFF
--- a/examples/twittermap/web/app/controllers/MySqlTwitterMapApplicaton.scala
+++ b/examples/twittermap/web/app/controllers/MySqlTwitterMapApplicaton.scala
@@ -24,6 +24,7 @@ class MySqlTwitterMapApplication @Inject()(val wsClient: WSClient,
   val predefinedKeywords: Seq[String] = config.getStringSeq("predefinedKeywords").getOrElse(Seq())
   val startDate: String = config.getString("startDate").getOrElse("2015-11-22T00:00:00.000")
   val endDate : Option[String] = config.getString("endDate")
+  val cacheThreshold : Option[String] = config.getString("cacheThreshold")
 
   val clientLogger = Logger("client")
 
@@ -34,7 +35,7 @@ class MySqlTwitterMapApplication @Inject()(val wsClient: WSClient,
     val remoteAddress = request.remoteAddress
     val userAgent = request.headers.get("user-agent").getOrElse("unknown")
     clientLogger.info(s"Connected: user_IP_address = $remoteAddress; user_agent = $userAgent")
-    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, false, true))
+    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, cacheThreshold, false, true))
   }
 
 }

--- a/examples/twittermap/web/app/controllers/TwitterMapApplication.scala
+++ b/examples/twittermap/web/app/controllers/TwitterMapApplication.scala
@@ -29,6 +29,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   val startDate: String = config.getString("startDate").getOrElse("2015-11-22T00:00:00.000")
   val endDate : Option[String] = config.getString("endDate")
   val cities: List[JsValue] = TwitterMapApplication.loadCity(environment.getFile(USCityDataPath))
+  val cacheThreshold : Option[String] = config.getString("cacheThreshold")
 
   val clientLogger = Logger("client")
 
@@ -39,7 +40,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
     val remoteAddress = request.remoteAddress
     val userAgent = request.headers.get("user-agent").getOrElse("unknown")
     clientLogger.info(s"Connected: user_IP_address = $remoteAddress; user_agent = $userAgent")
-    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, false))
+    Ok(views.html.twittermap.index("TwitterMap", cloudberryWS, startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, cacheThreshold, false))
   }
 
   def drugmap = Action {
@@ -48,7 +49,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
       val remoteAddress = request.remoteAddress
       val userAgent = request.headers.get("user-agent").getOrElse("unknown")
       clientLogger.info(s"Connected: user_IP_address = $remoteAddress; user_agent = $userAgent")
-      Ok(views.html.twittermap.index("DrugMap", cloudberryWS, startDateDrugMap, endDate, false, sentimentUDF, true, Seq("drug"), true))
+      Ok(views.html.twittermap.index("DrugMap", cloudberryWS, startDateDrugMap, endDate, false, sentimentUDF, true, Seq("drug"), cacheThreshold, true))
   }
 
   def tweet(id: String) = Action.async {

--- a/examples/twittermap/web/app/views/twittermap/index.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/index.scala.html
@@ -1,5 +1,5 @@
 
-@(title: String, ws: String, startDate: String, endDate:Option[String], sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], isDrugMap: Boolean) @main(title, ws, startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, isDrugMap){
+@(title: String, ws: String, startDate: String, endDate:Option[String], sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], cacheThreshold: Option[String], isDrugMap: Boolean) @main(title, ws, startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, cacheThreshold, isDrugMap){
 <div xmlns="http://www.w3.org/1999/html" ng-controller="AppCtrl">
 
   <div class="map-group">

--- a/examples/twittermap/web/app/views/twittermap/main.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/main.scala.html
@@ -1,4 +1,4 @@
-@(title: String, ws: String, startDate: String, endDate: Option[String], sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], isDrugMap: Boolean)(body: Html)
+@(title: String, ws: String, startDate: String, endDate: Option[String], sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], cacheThreshold: Option[String], isDrugMap: Boolean)(body: Html)
 
 @import play.api.libs.json.Json
 
@@ -36,7 +36,13 @@
         sumText : "tweets",
       }
       removeSearchBar: @removeSearchBar,
-      predefinedKeywords: @Html(Json.stringify(Json.toJson(predefinedKeywords)))
+      predefinedKeywords: @Html(Json.stringify(Json.toJson(predefinedKeywords))),
+      @if(cacheThreshold.isDefined) {
+        cacheThreshold: @cacheThreshold,
+      } else {
+        // The default caching threshold value
+        cacheThreshold: new String("30000")
+      }
     }
   </script>
   <script src='@routes.Assets.versioned("lib/angularjs/angular.min.js")'></script>

--- a/examples/twittermap/web/conf/application.conf
+++ b/examples/twittermap/web/conf/application.conf
@@ -92,6 +92,14 @@ startDate = "2015-11-22T00:00:00.000"
 # Set the endDate if the data is stopped feeding
 # endDate = "2017-06-20T00:00:00.000"
 
+# Defines the maximum number of city polygons that can be cached in the browser.
+# The default value is 30000 and this is equal to the number of all cities.
+# If this value is set to a non-positive value (<= 0), then the caching feature will not be executed.
+# cacheThreshold = 30000
+
 # for the debug purpose, we can load a smaller json to speed up the front-end
 us.city.path = "/public/data/city.sample.json"
+# For an actual deployment, comment the above, uncomment the following and use it to display all cities.
+# us.city.path = "/public/data/city.json"
+
 tweet.url = "http://twitterMapIndex-search-proxy.herokuapp.com/search/tweets?q=%s"

--- a/examples/twittermap/web/public/javascripts/cache/services.js
+++ b/examples/twittermap/web/public/javascripts/cache/services.js
@@ -8,7 +8,6 @@ angular.module('cloudberry.cache', ['leaflet-directive', 'cloudberry.common'])
         var cacheSize = 0;
         var insertedTreeIDs = new Set();
         var cacheThreshold = cloudberryConfig.cacheThreshold; //hard limit
-        console.log("cacheThreshold " + cacheThreshold);
         var targetDeleteCount = 0;
         var deletedPolygonCount = 0;
         var preFetchDistance = 25; //25 miles

--- a/examples/twittermap/web/public/javascripts/cache/services.js
+++ b/examples/twittermap/web/public/javascripts/cache/services.js
@@ -1,13 +1,14 @@
 /*Cache module stores user requested city polygons.When Users requests these same city polygon area again we have it in cache
  and provide it to the user without sending http request.*/
 angular.module('cloudberry.cache', ['leaflet-directive', 'cloudberry.common'])
-    .service('Cache', function ($window, $http, $compile) {
+    .service('Cache', function ($window, $http, $compile, cloudberryConfig) {
 
         var cachedCityPolygonTree = rbush();
         var cachedRegion;
         var cacheSize = 0;
         var insertedTreeIDs = new Set();
-        var cacheThreshold = 2000;//hard limit
+        var cacheThreshold = cloudberryConfig.cacheThreshold; //hard limit
+        console.log("cacheThreshold " + cacheThreshold);
         var targetDeleteCount = 0;
         var deletedPolygonCount = 0;
         var preFetchDistance = 25; //25 miles

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -9,6 +9,7 @@ angular.module('cloudberry.common', [])
       normalizationUpscaleFactor: 1000 * 1000,
       normalizationUpscaleText: "/M",
       sentimentUpperBound: 4,
+      cacheThreshold: config.cacheThreshold,
       getPopulationTarget: function(parameters){
         switch (parameters.geoLevel) {
           case "state":

--- a/examples/twittermap/web/public/javascripts/timeseries/controllers.js
+++ b/examples/twittermap/web/public/javascripts/timeseries/controllers.js
@@ -131,7 +131,7 @@ angular.module('cloudberry.timeseries', ['cloudberry.common'])
             });
 
             var minDate = cloudberry.startDate;
-            var maxDate = new Date();
+            var maxDate = cloudberry.parameters.timeInterval.end;
             chart.selectAll('a').remove();
             chart.append('a')
                 .text('Reset')


### PR DESCRIPTION
- Can set the cache threshold in the config.
- Set the default cache threshold as 30,000.
- If the cache threshold is a non-positive value, the caching feature can be disabled.
  (Mainly for a temporary debug purpose. This can be removed once we are sure.)
- Two javascript error fix
  (resetGeoIDs and addLayer) 
