### PR TITLE
Fix the datatype creation statement

### DIFF
--- a/cloudberry/neo/app/db/Migration_20160814.scala
+++ b/cloudberry/neo/app/db/Migration_20160814.scala
@@ -45,7 +45,7 @@ private[db] class Migration_20160814() {
              |create type berry.metaType if not exists as open {
              | name : string,
              | stats : { createTime: string}
-             |}
+             |};
              |
              |create dataset $berryMeta(berry.metaType) if not exists primary key name;
        """.stripMargin


### PR DESCRIPTION
Fix the meta datatype creation statement by adding a semicolon at the end of it.
In SQLPP mode, AsterixDB now requires it.