### PR TITLE
Suggest view for the non-slicing queries

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
@@ -94,10 +94,10 @@ class BerryClient(val jsonParser: JSONParser,
       val (queries, runOption) = jsonParser.parse(request.json, schemaMap)
       if (runOption.sliceMills <= 0) {
         val futureResult = Future.traverse(queries)(q => solveAQuery(q)).map(JsArray.apply)
-        futureResult.foreach { r =>
+        futureResult.map(result => (queries, result)).foreach { case (qs,r) =>
           curSender ! request.postTransform.transform(r)
+          qs.foreach(suggestViews)
         }
-        queries.foreach(suggestViews)
       } else {
         val targetMillis = runOption.sliceMills
         val mapInfos = seqInfos.map(_.get).map(info => info.name -> info).toMap

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/SimpleBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/SimpleBerryClientTest.scala
@@ -59,6 +59,9 @@ class SimpleBerryClientTest extends TestkitExample with SpecificationLike with M
 
       sender.expectMsg(JsArray(Seq(JsArray(Seq(Json.obj("a" -> 4), Json.obj("b" -> 8))))))
 
+      dataManager.expectMsg(DataStoreManager.AskInfoAndViews(query.dataset))
+      dataManager.reply(Seq(sourceInfo))
+      dataManager.expectMsg(create)
       ok
     }
     "send the NoSuchData msg if the request is on a unknown dataset" in {


### PR DESCRIPTION
The previous code forgot to suggest a view when the query is *NOT* the slicing one. 
This PR fix that. 