### PR TITLE
Remove a duplicated query submission and an unnecessary parameter.

### DIFF
--- a/examples/twittermap/web/public/javascripts/common/services-drug.js
+++ b/examples/twittermap/web/public/javascripts/common/services-drug.js
@@ -261,7 +261,7 @@ angular.module('cloudberry.common', [])
       hashTagResult: [],
       errorMessage: null,
 
-      query: function(parameters, queryType) {
+      query: function(parameters) {
         var sampleJson = (JSON.stringify({
           dataset: parameters.dataset,
           filter: getFilter(parameters, defaultSamplingDayRange),

--- a/examples/twittermap/web/public/javascripts/common/services-mysql.js
+++ b/examples/twittermap/web/public/javascripts/common/services-mysql.js
@@ -190,7 +190,7 @@ angular.module('cloudberry.common', [])
       timeResult: [],
       errorMessage: null,
 
-      query: function(parameters, queryType) {
+      query: function(parameters) {
         var sampleJson = (JSON.stringify({
           dataset: parameters.dataset,
           filter: getFilter(parameters, defaultSamplingDayRange),

--- a/examples/twittermap/web/public/javascripts/common/services-postgresql.js
+++ b/examples/twittermap/web/public/javascripts/common/services-postgresql.js
@@ -218,7 +218,7 @@ angular.module('cloudberry.common', [])
       hashTagResult: [],
       errorMessage: null,
 
-      query: function(parameters, queryType) {
+      query: function(parameters) {
         var sampleJson = (JSON.stringify({
           dataset: parameters.dataset,
           filter: getFilter(parameters, defaultSamplingDayRange),

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -263,14 +263,12 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
         geoIds : [37,51,24,11,10,34,42,9,44,48,35,4,40,6,20,32,8,49,12,22,28,1,13,45,5,47,21,29,54,17,18,39,19,55,26,27,31,56,41,46,16,30,53,38,25,36,50,33,23,2]
       },
 
-      queryType: "search",
-
       mapResult: [],
       timeResult: [],
       hashTagResult: [],
       errorMessage: null,
 
-      query: function(parameters, queryType) {
+      query: function(parameters) {
 
         var sampleJson = (JSON.stringify({
           dataset: parameters.dataset,

--- a/examples/twittermap/web/public/javascripts/map/controllers.js
+++ b/examples/twittermap/web/public/javascripts/map/controllers.js
@@ -232,8 +232,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
           } else if ($scope.status.zoomLevel > 5) {
             resetGeoInfo("county");
             if (!$scope.status.init) {
-              cloudberry.queryType = 'zoom';
-              cloudberry.query(cloudberry.parameters, cloudberry.queryType);
+              cloudberry.query(cloudberry.parameters);
             }
             if($scope.polygons.statePolygons) {
               $scope.map.removeLayer($scope.polygons.statePolygons);
@@ -249,8 +248,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
           } else if ($scope.status.zoomLevel <= 5) {
             resetGeoInfo("state");
             if (!$scope.status.init) {
-              cloudberry.queryType = 'zoom';
-              cloudberry.query(cloudberry.parameters, cloudberry.queryType);
+              cloudberry.query(cloudberry.parameters);
             }
             if($scope.polygons.countyPolygons) {
               $scope.map.removeLayer($scope.polygons.countyPolygons);
@@ -289,11 +287,11 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
         }
         if ($scope.status.logicLevel === 'city') {
           loadCityJsonByBound(onEachFeature);
+        } else {
+          resetGeoIds($scope.bounds, geoData, $scope.status.logicLevel + "ID");
+          cloudberry.parameters.geoLevel = $scope.status.logicLevel;
+          cloudberry.query(cloudberry.parameters);
         }
-        resetGeoIds($scope.bounds, geoData, $scope.status.logicLevel + "ID");
-        cloudberry.parameters.geoLevel = $scope.status.logicLevel;
-        cloudberry.queryType = 'drag';
-        cloudberry.query(cloudberry.parameters, cloudberry.queryType);
       });
 
     }
@@ -382,8 +380,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
                 if (!$scope.status.init) {
                     resetGeoIds($scope.bounds, $scope.geojsonData.city, 'cityID');
                     cloudberry.parameters.geoLevel = 'city';
-                    cloudberry.queryType = 'zoom';
-                    cloudberry.query(cloudberry.parameters, cloudberry.queryType);
+                    cloudberry.query(cloudberry.parameters);
                 }
                 resetGeoInfo("city");
                 $scope.map.addLayer($scope.polygons.cityPolygons);
@@ -403,8 +400,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
                     setCenterAndBoundry($scope.geojsonData.city.features);
                     resetGeoInfo("city");
                     if (!$scope.status.init) {
-                        cloudberry.queryType = 'zoom';
-                        cloudberry.query(cloudberry.parameters, cloudberry.queryType);
+                        cloudberry.query(cloudberry.parameters);
                     }
                     $scope.map.addLayer($scope.polygons.cityPolygons);
                 })

--- a/examples/twittermap/web/public/javascripts/searchbar/controllers.js
+++ b/examples/twittermap/web/public/javascripts/searchbar/controllers.js
@@ -4,8 +4,7 @@ angular.module('cloudberry.util', ['cloudberry.common'])
       if ($scope.keyword && $scope.keyword.trim().length > 0) {
         cloudberry.parameters.keywords = $scope.keyword.trim().split(/\s+/);
         // skip the empty query for now.
-        cloudberry.queryType = 'search';
-        cloudberry.query(cloudberry.parameters, cloudberry.queryType);
+        cloudberry.query(cloudberry.parameters);
       } else {
         cloudberry.parameters.keywords = [];
       }

--- a/examples/twittermap/web/public/javascripts/timeseries/controllers.js
+++ b/examples/twittermap/web/public/javascripts/timeseries/controllers.js
@@ -121,8 +121,7 @@ angular.module('cloudberry.timeseries', ['cloudberry.common'])
             var requestFunc = function(min, max) {
               cloudberry.parameters.timeInterval.start = min;
               cloudberry.parameters.timeInterval.end = max;
-              cloudberry.queryType = 'time';
-              cloudberry.query(cloudberry.parameters, cloudberry.queryType);
+              cloudberry.query(cloudberry.parameters);
             };
 
             timeBrush.on('brushend', function (e) {


### PR DESCRIPTION
- Remove a duplicated query submission when dragging the current region at city level on the Twittermap.
- Remove an unnecessary parameter (queryType) in Twittermap.