### PR TITLE
Fix Query Slicing request bug on the front-end

### DIFF
--- a/examples/twittermap/web/public/javascripts/mapresultcache/services.js
+++ b/examples/twittermap/web/public/javascripts/mapresultcache/services.js
@@ -62,7 +62,7 @@ angular.module('cloudberry.mapresultcache', ['cloudberry.common'])
 
             for (var i = 0; i < geoIds.length; i++) {
                 var value = store.get(prefix[geoLevel] + geoIds[i]);
-                if (value !== INVALID_VALUE) {
+                if (value !==  undefined && value !== INVALID_VALUE) {
                     resultArray.push(value);
                 }
             }


### PR DESCRIPTION
- Fix Query Slicing request bug on the front-end (type casting issue)
- Integrate two map result cache handling case (partial hit + complete miss)
- Map result cache now returns the result if it truly contains something (add undefined handling)
