### PR TITLE
[Issue #432] Limit number of results returned

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
@@ -39,7 +39,7 @@ class BerryClient(val jsonParser: JSONParser,
 
   private case class QueryGroup(ts: DateTime, curSender: ActorRef, queries: Seq[QueryInfo], postTransform: IPostTransform)
 
-  private case class Initial(ts: DateTime, sender: ActorRef, targetMillis: Long, queries: Seq[Query], infos: Map[String, DataSetInfo], postTransform: IPostTransform)
+  private case class Initial(ts: DateTime, sender: ActorRef, targetMillis: Long, targetLimits: Int, queries: Seq[Query], infos: Map[String, DataSetInfo], postTransform: IPostTransform)
 
   private case class PartialResult(queryGroup: QueryGroup, jsons: Seq[JsArray])
 
@@ -73,7 +73,7 @@ class BerryClient(val jsonParser: JSONParser,
       val queryGroup = QueryGroup(initial.ts, initial.sender, queryInfos, initial.postTransform)
       val initResult = Seq.fill(queryInfos.size)(JsArray())
       issueQueryGroup(interval, queryGroup)
-      context.become(askSlice(initial.targetMillis, interval, boundary, queryGroup, initResult, askTime = DateTime.now), discardOld = true)
+      context.become(askSlice(initial.targetMillis, initial.targetLimits, interval, boundary, queryGroup, initResult, askTime = DateTime.now), discardOld = true)
   }
 
   private def handleNewRequest(request: Request, curSender: ActorRef): Unit = {
@@ -100,13 +100,15 @@ class BerryClient(val jsonParser: JSONParser,
         }
       } else {
         val targetMillis = runOption.sliceMills
+        val targetLimits = runOption.limit
         val mapInfos = seqInfos.map(_.get).map(info => info.name -> info).toMap
-        self ! Initial(key, curSender, targetMillis, queries, mapInfos, request.postTransform)
+        self ! Initial(key, curSender, targetMillis, targetLimits, queries, mapInfos, request.postTransform)
       }
     }
   }
 
   private def askSlice(targetInvertal: Long,
+                       targetLimits: Int,
                        curInterval: TInterval,
                        boundary: TInterval,
                        queryGroup: QueryGroup,
@@ -116,17 +118,19 @@ class BerryClient(val jsonParser: JSONParser,
       val mergedResults = queryGroup.queries.zipWithIndex.map { case (q, idx) =>
         q.merger(Seq(accumulateResults(idx), result.jsons(idx)))
       }
-      queryGroup.curSender ! queryGroup.postTransform.transform(JsArray(mergedResults))
-
       val timeSpend = DateTime.now.getMillis - askTime.getMillis
       val nextInterval = calculateNext(targetInvertal, curInterval, timeSpend, boundary)
-      if (nextInterval.toDurationMillis <= 0) {
+
+      if (nextInterval.toDurationMillis <= 0 || mergedResults.size >= targetLimits) {
+        val returnedResult = if (mergedResults.size > targetLimits) mergedResults.take(targetLimits) else mergedResults
+        queryGroup.curSender ! queryGroup.postTransform.transform(JsArray(returnedResult))
         queryGroup.curSender ! queryGroup.postTransform.transform(BerryClient.Done) // notifying the client the processing is done
         queryGroup.queries.foreach(qinfo => suggestViews(qinfo.query))
         context.become(receive, discardOld = true)
       } else {
+        queryGroup.curSender ! queryGroup.postTransform.transform(JsArray(mergedResults))
         issueQueryGroup(nextInterval, queryGroup)
-        context.become(askSlice(targetInvertal, nextInterval, boundary, queryGroup, mergedResults, DateTime.now), discardOld = true)
+        context.become(askSlice(targetInvertal, targetLimits, nextInterval, boundary, queryGroup, mergedResults, DateTime.now), discardOld = true)
       }
     case json: JsValue =>
       stash()

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
@@ -121,6 +121,8 @@ class BerryClient(val jsonParser: JSONParser,
       val timeSpend = DateTime.now.getMillis - askTime.getMillis
       val nextInterval = calculateNext(targetInvertal, curInterval, timeSpend, boundary)
 
+      //TODO change here
+
       if (nextInterval.toDurationMillis <= 0 || mergedResults.size >= targetLimits) {
         val returnedResult = if (mergedResults.size > targetLimits) mergedResults.take(targetLimits) else mergedResults
         queryGroup.curSender ! queryGroup.postTransform.transform(JsArray(returnedResult))

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
@@ -125,9 +125,6 @@ class BerryClient(val jsonParser: JSONParser,
         val returnedResult =
           if (mergedResults.head.value.size > targetLimits) Seq(JsArray(mergedResults.head.value.take(targetLimits)))
           else mergedResults
-
-        println(returnedResult.toString())
-
         queryGroup.curSender ! queryGroup.postTransform.transform(JsArray(returnedResult))
         queryGroup.curSender ! queryGroup.postTransform.transform(BerryClient.Done) // notifying the client the processing is done
         queryGroup.queries.foreach(qinfo => suggestViews(qinfo.query))

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
@@ -264,7 +264,7 @@ object JSONParser {
   implicit val exeOptionReads: Reads[QueryExeOption] = (
     (__ \ QueryExeOption.TagSliceMillis).readNullable[Int].map(_.getOrElse(-1)) and
       (__ \ QueryExeOption.TagContinueSeconds).readNullable[Int].map(_.getOrElse(-1)) and
-      (__ \ QueryExeOption.TagLimit).readNullable[Int].map(_.getOrElse(-1))
+      (__ \ QueryExeOption.TagLimit).readNullable[Int].map(_.getOrElse(Int.MaxValue))
     ) (QueryExeOption.apply _)
 
 

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
@@ -24,13 +24,19 @@ class JSONParser extends IJSONParser {
     * Finally, calls [[QueryValidator]] to validate the correctness of this query.
     */
   override def parse(json: JsValue, schemaMap: Map[String, AbstractSchema]): (Seq[Query], QueryExeOption) = {
-    val option = (json \ "option").toOption.map(_.as[QueryExeOption]).getOrElse(QueryExeOption.NoSliceNoContinue)
-    val query = (json \ "batch").toOption match {
+    val (processedJson, option) = extractQueryExeOption(json)
+
+
+    println(processedJson.toString())
+    println(option.toString)
+
+
+    val query = (processedJson \ "batch").toOption match {
       case Some(groupRequest) => groupRequest.validate[Seq[UnresolvedQuery]] match {
         case js: JsSuccess[Seq[UnresolvedQuery]] => js.get
         case e: JsError => throw JsonRequestException(JsError.toJson(e).toString())
       }
-      case None => json.validate[UnresolvedQuery] match {
+      case None => processedJson.validate[UnresolvedQuery] match {
         case js: JsSuccess[UnresolvedQuery] => Seq(js.get)
         case e: JsError => throw JsonRequestException(JsError.toJson(e).toString())
       }
@@ -56,6 +62,41 @@ object JSONParser {
     resolved
   }
 
+  /**
+    * Parses json request and extract [[QueryExeOption]], then removes all option-related field from requests.
+    *
+    * @param json
+    * @return
+    */
+  def extractQueryExeOption(json: JsValue): (JsValue, QueryExeOption) = {
+    val option = (json \ "option").toOption.map(_.as[JsonRequestOption]).getOrElse(JsonRequestOption.NoSliceNoContinue)
+    option match {
+      case JsonRequestOption.NoSliceNoContinue =>
+        (json, QueryExeOption.DefaultOption)
+      case _ =>
+        (json \ "batch").toOption match {
+          case Some(_) if (json \\ "limit").isEmpty || ((json \\ "limit").nonEmpty && (json \\ "aggregate").nonEmpty) =>
+            // enable batch requests with timeline and TopK hashtag requests
+            // TODO disable when front end change
+            (json, QueryExeOption(option.sliceMills, option.continueSeconds, Int.MaxValue))
+          case Some(_) =>
+            throw JsonRequestException("Batch Requests cannot contain \"limit\" field")
+          case None if (json \\ "limit").isEmpty =>
+            (json, QueryExeOption(option.sliceMills, option.continueSeconds, Int.MaxValue))
+          // reassign limit value if something other than "limit" in select statement
+          case None if (json \\ "order").nonEmpty || (json \\ "offset").nonEmpty =>
+            val limit = (json \ "select" \ "limit").as[Int]
+            val updatedSelectJson = (json \ "select").as[JsObject] ++ Json.obj("limit" -> Int.MaxValue)
+            val updatedJson = json.as[JsObject] ++ Json.obj("select" -> updatedSelectJson)
+            (updatedJson, QueryExeOption(option.sliceMills, option.continueSeconds, limit))
+          // remove select statement if only "limit" field found
+          case None =>
+            val limit = (json \ "select" \ "limit").as[Int]
+            val updatedJson = json.as[JsObject] - "select"
+            (updatedJson, QueryExeOption(option.sliceMills, option.continueSeconds, limit))
+        }
+    }
+  }
 
   implicit val seqAnyValue: Format[Seq[Any]] = new Format[Seq[Any]] {
     override def reads(json: JsValue): JsResult[Seq[Any]] = {
@@ -261,11 +302,10 @@ object JSONParser {
       (JsPath \ "values").format[Seq[Any]]
     ) (UnresolvedFilterStatement.apply, unlift(UnresolvedFilterStatement.unapply))
 
-  implicit val exeOptionReads: Reads[QueryExeOption] = (
-    (__ \ QueryExeOption.TagSliceMillis).readNullable[Int].map(_.getOrElse(-1)) and
-      (__ \ QueryExeOption.TagContinueSeconds).readNullable[Int].map(_.getOrElse(-1)) and
-      (__ \ QueryExeOption.TagLimit).readNullable[Int].map(_.getOrElse(Int.MaxValue))
-    ) (QueryExeOption.apply _)
+  implicit val exeOptionReads: Reads[JsonRequestOption] = (
+    (__ \ JsonRequestOption.TagSliceMillis).readNullable[Int].map(_.getOrElse(-1)) and
+      (__ \ JsonRequestOption.TagContinueSeconds).readNullable[Int].map(_.getOrElse(-1))
+    ) (JsonRequestOption.apply _)
 
 
   // TODO find better name for 'global'

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
@@ -25,12 +25,6 @@ class JSONParser extends IJSONParser {
     */
   override def parse(json: JsValue, schemaMap: Map[String, AbstractSchema]): (Seq[Query], QueryExeOption) = {
     val (processedJson, option) = extractQueryExeOption(json)
-
-
-    println(processedJson.toString())
-    println(option.toString)
-
-
     val query = (processedJson \ "batch").toOption match {
       case Some(groupRequest) => groupRequest.validate[Seq[UnresolvedQuery]] match {
         case js: JsSuccess[Seq[UnresolvedQuery]] => js.get

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParser.scala
@@ -263,7 +263,8 @@ object JSONParser {
 
   implicit val exeOptionReads: Reads[QueryExeOption] = (
     (__ \ QueryExeOption.TagSliceMillis).readNullable[Int].map(_.getOrElse(-1)) and
-      (__ \ QueryExeOption.TagContinueSeconds).readNullable[Int].map(_.getOrElse(-1))
+      (__ \ QueryExeOption.TagContinueSeconds).readNullable[Int].map(_.getOrElse(-1)) and
+      (__ \ QueryExeOption.TagLimit).readNullable[Int].map(_.getOrElse(-1))
     ) (QueryExeOption.apply _)
 
 

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
@@ -15,21 +15,16 @@ trait IWriteQuery extends IQuery {
 
 }
 
-case class JsonRequestOption(sliceMills: Int,
-                             continueSeconds: Int)
-
-object JsonRequestOption {
-  val NoSliceNoContinue = JsonRequestOption(-1, -1)
-  val TagSliceMillis = "sliceMillis"
-  val TagContinueSeconds = "continueSeconds"
-}
-
 case class QueryExeOption(sliceMills: Int,
                           continueSeconds: Int,
                           limit: Int)
 
 object QueryExeOption {
-  val DefaultOption = QueryExeOption(-1, -1, Int.MaxValue)
+  val NoSliceNoContinue = QueryExeOption(-1, -1, Int.MaxValue)
+  val TagSliceMillis = "sliceMillis"
+  val TagContinueSeconds = "continueSeconds"
+  //TODO limit tag should be in the query
+  val TagLimit = "limit"
 }
 
 case class Query(dataset: String,

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
@@ -16,12 +16,14 @@ trait IWriteQuery extends IQuery {
 }
 
 case class QueryExeOption(sliceMills: Int,
-                          continueSeconds: Int)
+                          continueSeconds: Int,
+                          limit: Int)
 
 object QueryExeOption {
-  val NoSliceNoContinue = QueryExeOption(-1, -1)
+  val NoSliceNoContinue = QueryExeOption(-1, -1, -1)
   val TagSliceMillis = "sliceMillis"
   val TagContinueSeconds = "continueSeconds"
+  val TagLimit = "limit"
 }
 
 case class Query(dataset: String,

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
@@ -15,16 +15,21 @@ trait IWriteQuery extends IQuery {
 
 }
 
-// limit constrains that the maximum number of results that can be returned is 2^31 ~ 2.1 billion
+case class JsonRequestOption(sliceMills: Int,
+                             continueSeconds: Int)
+
+object JsonRequestOption {
+  val NoSliceNoContinue = JsonRequestOption(-1, -1)
+  val TagSliceMillis = "sliceMillis"
+  val TagContinueSeconds = "continueSeconds"
+}
+
 case class QueryExeOption(sliceMills: Int,
                           continueSeconds: Int,
                           limit: Int)
 
 object QueryExeOption {
-  val NoSliceNoContinue = QueryExeOption(-1, -1, Int.MaxValue)
-  val TagSliceMillis = "sliceMillis"
-  val TagContinueSeconds = "continueSeconds"
-  val TagLimit = "limit"
+  val DefaultOption = QueryExeOption(-1, -1, Int.MaxValue)
 }
 
 case class Query(dataset: String,

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/Query.scala
@@ -15,12 +15,13 @@ trait IWriteQuery extends IQuery {
 
 }
 
+// limit constrains that the maximum number of results that can be returned is 2^31 ~ 2.1 billion
 case class QueryExeOption(sliceMills: Int,
                           continueSeconds: Int,
                           limit: Int)
 
 object QueryExeOption {
-  val NoSliceNoContinue = QueryExeOption(-1, -1, -1)
+  val NoSliceNoContinue = QueryExeOption(-1, -1, Int.MaxValue)
   val TagSliceMillis = "sliceMillis"
   val TagContinueSeconds = "continueSeconds"
   val TagLimit = "limit"

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.cloudberry.zion.TInterval
 import edu.uci.ics.cloudberry.zion.common.Config
 import edu.uci.ics.cloudberry.zion.model.impl.QueryPlanner.{IMerger, Unioner}
 import edu.uci.ics.cloudberry.zion.model.impl.{JSONParser, QueryPlanner, TestQuery}
-import edu.uci.ics.cloudberry.zion.model.schema.{CreateView, Query, QueryExeOption, Field, TimeField}
+import edu.uci.ics.cloudberry.zion.model.schema._
 import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -154,7 +154,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
 
 
   def makeOptionJsonObj(json: JsValue): JsObject = {
-    json.asInstanceOf[JsObject] + ("option" -> Json.obj(QueryExeOption.TagSliceMillis -> JsNumber(50)))
+    json.asInstanceOf[JsObject] + ("option" -> Json.obj(JsonRequestOption.TagSliceMillis -> JsNumber(50)))
   }
 
   def getRet(i: Int) = JsArray(Seq(JsObject(Seq("hour" -> JsNumber(i), "count" -> JsNumber(i)))))

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -431,5 +431,60 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
 
       ok
     }
+    "stop when the number of returning results reached the limit" in {
+      val sender = new TestProbe(system)
+      val dataManager = new TestProbe(system)
+      val parser = new JSONParser
+      val mockPlanner = mock[QueryPlanner]
+      when(mockPlanner.calculateMergeFunc(any, any)).thenReturn(QueryPlanner.Unioner)
+      //Return the input query
+      when(mockPlanner.makePlan(any, any, any)).thenAnswer(new Answer[(Seq[Query], IMerger)] {
+        override def answer(invocation: InvocationOnMock): (Seq[Query], IMerger) = {
+          val query = invocation.getArguments().head.asInstanceOf[Query]
+          (Seq(query), Unioner)
+        }
+      })
+
+      val client = system.actorOf(BerryClient.props(parser, dataManager.ref, mockPlanner, Config.Default))
+
+      val selectJson = Json.obj(
+        "limit" -> JsNumber(2)
+      )
+      sender.send(client, makeOptionJsonObj(hourCountJSON.as[JsObject] + ("select" -> selectJson)))
+      val askInfo = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
+      askInfo.who must_== "twitter.ds_tweet"
+      dataManager.reply(Some(TestQuery.sourceInfo))
+
+      dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
+      dataManager.reply(Seq(TestQuery.sourceInfo))
+
+      val slicedQ1 = dataManager.receiveOne(5 seconds).asInstanceOf[Query]
+      val interval1 = slicedQ1.getTimeInterval(TimeField("create_at")).get
+      interval1.getEnd must_== endTime
+      interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
+
+      dataManager.reply(getRet(1))
+      sender.expectMsg(JsArray(Seq(getRet(1))))
+
+      dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
+      dataManager.reply(Seq(TestQuery.sourceInfo))
+      val slicedQ2 = dataManager.receiveOne(5 seconds).asInstanceOf[Query]
+      val interval2 = slicedQ2.getTimeInterval(TimeField("create_at")).get
+      interval2.getEnd must_== interval1.getStart
+      interval2.getStartMillis must be_>=(startTime.getMillis)
+
+      dataManager.reply(JsArray(Seq(
+        Json.obj("hour" -> 2, "count" -> 2),
+        Json.obj("hour" -> 3, "count" -> 3),
+        Json.obj("hour" -> 4, "count" -> 4)
+      )))
+      sender.expectMsg(JsArray(Seq(getRet(1) ++ getRet(2))))
+
+      dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
+      dataManager.reply(Seq(TestQuery.sourceInfo))
+      dataManager.expectNoMsg()
+      sender.expectMsg(BerryClient.Done)
+      ok
+    }
   }
 }

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -7,6 +7,7 @@ import edu.uci.ics.cloudberry.zion.TInterval
 import edu.uci.ics.cloudberry.zion.common.Config
 import edu.uci.ics.cloudberry.zion.model.impl.QueryPlanner.{IMerger, Unioner}
 import edu.uci.ics.cloudberry.zion.model.impl.{JSONParser, QueryPlanner, TestQuery}
+import edu.uci.ics.cloudberry.zion.model.schema
 import edu.uci.ics.cloudberry.zion.model.schema._
 import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.invocation.InvocationOnMock
@@ -154,7 +155,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
 
 
   def makeOptionJsonObj(json: JsValue): JsObject = {
-    json.asInstanceOf[JsObject] + ("option" -> Json.obj(JsonRequestOption.TagSliceMillis -> JsNumber(50)))
+    json.asInstanceOf[JsObject] + ("option" -> Json.obj(QueryExeOption.TagSliceMillis -> JsNumber(50)))
   }
 
   def getRet(i: Int) = JsArray(Seq(JsObject(Seq("hour" -> JsNumber(i), "count" -> JsNumber(i)))))
@@ -447,10 +448,11 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
 
       val client = system.actorOf(BerryClient.props(parser, dataManager.ref, mockPlanner, Config.Default))
 
-      val selectJson = Json.obj(
-        "limit" -> JsNumber(2)
+      val optionJson = Json.obj(
+        QueryExeOption.TagSliceMillis -> JsNumber(50),
+        QueryExeOption.TagLimit -> JsNumber(2)
       )
-      sender.send(client, makeOptionJsonObj(hourCountJSON.as[JsObject] + ("select" -> selectJson)))
+      sender.send(client, hourCountJSON.as[JsObject] + ("option" -> optionJson))
       val askInfo = dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfo]
       askInfo.who must_== "twitter.ds_tweet"
       dataManager.reply(Some(TestQuery.sourceInfo))

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/SimpleBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/SimpleBerryClientTest.scala
@@ -30,7 +30,7 @@ class SimpleBerryClientTest extends TestkitExample with SpecificationLike with M
 
       val jsonRequest = JsObject(Seq("fake" -> JsNumber(1)))
       val query = Query(sourceInfo.name)
-      when(mockParser.parse(jsonRequest, twitterSchemaMap)).thenReturn((Seq(query), QueryExeOption.DefaultOption))
+      when(mockParser.parse(jsonRequest, twitterSchemaMap)).thenReturn((Seq(query), QueryExeOption.NoSliceNoContinue))
       when(mockParser.getDatasets(jsonRequest)).thenReturn(Set(TwitterDataSet))
 
       val client = system.actorOf(BerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default))
@@ -72,7 +72,7 @@ class SimpleBerryClientTest extends TestkitExample with SpecificationLike with M
 
       val jsonRequest = JsObject(Seq("fake" -> JsNumber(1)))
       val query = Query(sourceInfo.name)
-      when(mockParser.parse(jsonRequest, twitterSchemaMap)).thenReturn((Seq(query), QueryExeOption.DefaultOption))
+      when(mockParser.parse(jsonRequest, twitterSchemaMap)).thenReturn((Seq(query), QueryExeOption.NoSliceNoContinue))
       when(mockParser.getDatasets(jsonRequest)).thenReturn(Set(sourceInfo.name))
 
 

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/SimpleBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/SimpleBerryClientTest.scala
@@ -30,7 +30,7 @@ class SimpleBerryClientTest extends TestkitExample with SpecificationLike with M
 
       val jsonRequest = JsObject(Seq("fake" -> JsNumber(1)))
       val query = Query(sourceInfo.name)
-      when(mockParser.parse(jsonRequest, twitterSchemaMap)).thenReturn((Seq(query), QueryExeOption.NoSliceNoContinue))
+      when(mockParser.parse(jsonRequest, twitterSchemaMap)).thenReturn((Seq(query), QueryExeOption.DefaultOption))
       when(mockParser.getDatasets(jsonRequest)).thenReturn(Set(TwitterDataSet))
 
       val client = system.actorOf(BerryClient.props(mockParser, dataManager.ref, mockPlanner, Config.Default))
@@ -72,7 +72,7 @@ class SimpleBerryClientTest extends TestkitExample with SpecificationLike with M
 
       val jsonRequest = JsObject(Seq("fake" -> JsNumber(1)))
       val query = Query(sourceInfo.name)
-      when(mockParser.parse(jsonRequest, twitterSchemaMap)).thenReturn((Seq(query), QueryExeOption.NoSliceNoContinue))
+      when(mockParser.parse(jsonRequest, twitterSchemaMap)).thenReturn((Seq(query), QueryExeOption.DefaultOption))
       when(mockParser.getDatasets(jsonRequest)).thenReturn(Set(sourceInfo.name))
 
 

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParserTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParserTest.scala
@@ -189,6 +189,7 @@ class JSONParserTest extends Specification {
       val (_, option) = parser.parse(hourCountJSON.asInstanceOf[JsObject] + ("option" -> optionJson), twitterSchemaMap)
       option.sliceMills must_== millis
       option.continueSeconds must be_<=(0)
+      option.limit must be_<=(0)
     }
     "parse continue option" in {
       val seconds = 4321
@@ -196,15 +197,27 @@ class JSONParserTest extends Specification {
       val (_, option) = parser.parse(hourCountJSON.asInstanceOf[JsObject] + ("option" -> optionJson), twitterSchemaMap)
       option.continueSeconds must_== seconds
       option.sliceMills must be_<=(0)
+      option.limit must be_<=(0)
     }
-    "parse continue and slicing option" in {
+    "parse result limit option" in {
+      val limit = 1000
+      val optionJson = Json.obj(QueryExeOption.TagLimit -> JsNumber(1000))
+      val (_, option) = parser.parse(hourCountJSON.asInstanceOf[JsObject] + ("option" -> optionJson), twitterSchemaMap)
+      option.sliceMills must be_<=(0)
+      option.continueSeconds must be_<=(0)
+      option.limit must_== limit
+    }
+    "parse slicing and continue and limit option" in {
 
       val optionJson = Json.obj(
         QueryExeOption.TagSliceMillis -> JsNumber(1234),
-        QueryExeOption.TagContinueSeconds -> JsNumber(4321))
+        QueryExeOption.TagContinueSeconds -> JsNumber(4321),
+        QueryExeOption.TagLimit -> JsNumber(1000)
+      )
       val (_, option) = parser.parse(hourCountJSON.asInstanceOf[JsObject] + ("option" -> optionJson), twitterSchemaMap)
       option.continueSeconds must_== 4321
       option.sliceMills must_== 1234
+      option.limit must_== 1000
     }
     "parse estimable query if estimable field appears" in {
       val (queries, _) = parser.parse(hourCountJSON.asInstanceOf[JsObject] + ("estimable" -> JsBoolean(true)), twitterSchemaMap)
@@ -240,12 +253,17 @@ class JSONParserTest extends Specification {
     }
     "parse a batch of queries with option" in {
       val batchQueryJson = Json.obj("batch" -> JsArray(Seq(hourCountJSON, groupByBinJSON)))
-      val optionJson = Json.obj(QueryExeOption.TagSliceMillis -> JsNumber(1234))
+      val optionJson = Json.obj(
+        QueryExeOption.TagSliceMillis -> JsNumber(1234),
+        QueryExeOption.TagLimit -> JsNumber(1000)
+      )
       val (query, option) = parser.parse(batchQueryJson + ("option" -> optionJson), twitterSchemaMap)
       query.size must_== 2
       query.head must_== Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byHour), Seq(aggrCount))), None)
       query.last must_== Query(TwitterDataSet, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Some(GroupStatement(Seq(byBin), Seq(aggrCount))), None)
       option.sliceMills must_== 1234
+      option.continueSeconds must be_<=(0)
+      option.limit must_== 1000
     }
   }
 

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParserTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/JSONParserTest.scala
@@ -189,7 +189,7 @@ class JSONParserTest extends Specification {
       val (_, option) = parser.parse(hourCountJSON.asInstanceOf[JsObject] + ("option" -> optionJson), twitterSchemaMap)
       option.sliceMills must_== millis
       option.continueSeconds must be_<=(0)
-      option.limit must be_<=(0)
+      option.limit must_== Int.MaxValue
     }
     "parse continue option" in {
       val seconds = 4321
@@ -197,7 +197,7 @@ class JSONParserTest extends Specification {
       val (_, option) = parser.parse(hourCountJSON.asInstanceOf[JsObject] + ("option" -> optionJson), twitterSchemaMap)
       option.continueSeconds must_== seconds
       option.sliceMills must be_<=(0)
-      option.limit must be_<=(0)
+      option.limit must_== Int.MaxValue
     }
     "parse result limit option" in {
       val limit = 1000

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestQuery.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestQuery.scala
@@ -130,6 +130,7 @@ object TestQuery {
   val selectTop10Tag = SelectStatement(Seq(count), Seq(SortOrder.DSC), 10, 0, Seq.empty)
   val selectTop100 = SelectStatement(Seq.empty, Seq(SortOrder.DSC), 100, 0, Seq.empty)
   val selectTop10byHashTag = SelectStatement(Seq(count), Seq(SortOrder.DSC), 10, 0, Seq(hash))
+  val selectTagWithoutLimit = SelectStatement(Seq(count), Seq(SortOrder.DSC), Int.MaxValue, 0, Seq.empty)
   val selectAllOrderByTimeDesc = SelectStatement(Seq(createAt), Seq(SortOrder.DSC), 100, 0, Seq.empty)
   val selectCreateTimeByRange = SelectStatement(Seq.empty, Seq.empty, 0, 0, Seq(createAt))
 


### PR DESCRIPTION
This PR related to Issue #432 

**Note**
- Updated json parser to parse limit number.
- Checked the number of results each time before returning them. Once reaching the limit, send `Done` message and stop querying.

**Test**
- Added test case to Json parser and cloudberry client.
- All unit test cases pass.
- Tested on current TwitterMap.