### PR TITLE
A debug version on testing websocket overhead

### DIFF
--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -355,9 +355,6 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
 
               ws.send(sampleJson);
               ws.send(batchWithPartialGeoRequest);
-
-              console.log(new Date().getTime() + "\t" + parameters.keywords);
-
             }
             break;
             
@@ -416,6 +413,8 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
             }));
 
             ws.send(pointsJson);
+            console.time("sample response time");
+
             ws.send(pointsTimeJson);
             break;
           
@@ -446,13 +445,6 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
           case "batchWithPartialGeoRequest":
             if(angular.isArray(result.value)) {
               cloudberryService.timeResult = result.value[0];
-
-              var resultSize = 0;
-              for (var i = 0; i < result.value[0].length; i++) {
-                resultSize += result.value[0][i].count;
-              }
-              console.log(new Date().getTime() + "\t" + resultSize);
-
               cloudberryService.mapResult = result.value[1].concat(cloudberryService.partialMapResult);
               cloudberryService.hashTagResult = result.value[2];
             }
@@ -471,6 +463,8 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
             if(angular.isArray(result.value)) {
               cloudberryService.tweetResult = result.value[0].slice(0, defaultSamplingSize - 1);
               cloudberryService.pointsResult = result.value[0];
+
+              console.timeEnd("sample response time");
             }
             break;
           case "pointsTime":

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -355,6 +355,9 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
 
               ws.send(sampleJson);
               ws.send(batchWithPartialGeoRequest);
+
+              console.log(new Date().getTime() + "\t" + parameters.keywords);
+
             }
             break;
             
@@ -443,6 +446,13 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
           case "batchWithPartialGeoRequest":
             if(angular.isArray(result.value)) {
               cloudberryService.timeResult = result.value[0];
+
+              var resultSize = 0;
+              for (var i = 0; i < result.value[0].length; i++) {
+                resultSize += result.value[0][i].count;
+              }
+              console.log(new Date().getTime() + "\t" + resultSize);
+
               cloudberryService.mapResult = result.value[1].concat(cloudberryService.partialMapResult);
               cloudberryService.hashTagResult = result.value[2];
             }

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -1,7 +1,11 @@
 angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
   .factory('cloudberryConfig', function(){
     return {
-      ws: "ws://" + location.host + "/ws",
+
+      // 4-layer config: "ws://" + location.host + "/ws",
+      // 3-layer config: "ws://localhost:9000/ws"
+      ws: "ws://localhost:9000/ws",
+        
       sentimentEnabled: config.sentimentEnabled,
       sentimentUDF: config.sentimentUDF,
       removeSearchBar: config.removeSearchBar,


### PR DESCRIPTION
This is the **debug** version to test websocket server overhead when we switch 3-layer to 4-layer architecture. We could keep it in a debug branch and test it in production when available.

I have tested some of the keywords search locally and below is the experimental data.

<img width="585" alt="screen shot 2017-12-07 at 8 29 01 pm" src="https://user-images.githubusercontent.com/19794264/33751108-7c2e7132-db8d-11e7-9c56-c27a3120d4df.png">
