### PR TITLE
Fix time series and tweet count issues in pointmap

### DIFF
--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -108,7 +108,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
           values: keywords
         }
       ];
-      if (typeof(geoIds) !== "undefined" && geoIds != null && geoIds.length <= 2000){
+      if (geoIds.length <= 2000 && parameters.maptype === 'countmap'){
         filter.push(
           {
             field: "geo_tag." + spatialField,
@@ -368,7 +368,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
 
             var pointsJson = (JSON.stringify({
               dataset: parameters.dataset,
-              filter: getFilter(parameters, defaultPointmapSamplingDayRange),
+              filter: getFilter(parameters, defaultPointmapSamplingDayRange, parameters.geoIds),
               select: {
                 order: ["-create_at"],
                 limit: defaultPointmapLimit,

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -271,7 +271,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
       hashTagResult: [],
       errorMessage: null,
 
-      query: function(parameters) {
+      query: function(parameters, getPoints=true) {
       
         if (ws.readyState !== ws.OPEN || typeof(parameters.keywords) === "undefined" || parameters.keywords == null || parameters.keywords.length == 0)
           return;
@@ -414,8 +414,10 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
                 }
               }
             }));
-
-            ws.send(pointsJson);
+            
+            if (getPoints){
+              ws.send(pointsJson);
+            }
             ws.send(pointsTimeJson);
             break;
           

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -273,7 +273,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
 
       query: function(parameters) {
       
-        if (ws.readyState !== ws.OPEN || parameters.keywords == null || parameters.keywords.length == 0)
+        if (ws.readyState !== ws.OPEN || typeof(parameters.keywords) === "undefined" || parameters.keywords == null || parameters.keywords.length == 0)
           return;
 
         // generate query based on map type
@@ -482,7 +482,6 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
             break;
           default:
             console.log("ws get unknown data: ", result);
-            //cloudberryService.errorMessage = "ws get unknown data: " + result.toString();
             break;
         }
       });

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -47,7 +47,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
     var defaultNonSamplingDayRange = 1500;
     var defaultSamplingDayRange = 1;
     var defaultSamplingSize = 10;
-    var defaultPointmapSamplingDayRange = 30;
+    var defaultPointmapSamplingDayRange = 7;
     var defaultPointmapLimit = 25*1000;
     var ws = new WebSocket(cloudberryConfig.ws);
     // The MapResultCache.getGeoIdsNotInCache() method returns the geoIds
@@ -108,7 +108,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
           values: keywords
         }
       ];
-      if (geoIds.length <= 2000){
+      if (geoIds.length <= 2000 && parameters.maptype === 'countmap'){
         filter.push(
           {
             field: "geo_tag." + spatialField,

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -272,6 +272,9 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
       errorMessage: null,
 
       query: function(parameters) {
+      
+        if (ws.readyState !== ws.OPEN || parameters.keywords == null || parameters.keywords.length == 0)
+          return;
 
         // generate query based on map type
         switch (parameters.maptype) {
@@ -478,7 +481,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
           case "done":
             break;
           default:
-            console.error("ws get unknown data: ", result);
+            console.log("ws get unknown data: ", result);
             cloudberryService.errorMessage = "ws get unknown data: " + result.toString();
             break;
         }

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -482,7 +482,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
             break;
           default:
             console.log("ws get unknown data: ", result);
-            cloudberryService.errorMessage = "ws get unknown data: " + result.toString();
+            //cloudberryService.errorMessage = "ws get unknown data: " + result.toString();
             break;
         }
       });

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -108,7 +108,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
           values: keywords
         }
       ];
-      if (geoIds.length <= 2000 && parameters.maptype === 'countmap'){
+      if (typeof(geoIds) !== "undefined" && geoIds != null && geoIds.length <= 2000){
         filter.push(
           {
             field: "geo_tag." + spatialField,
@@ -368,7 +368,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
 
             var pointsJson = (JSON.stringify({
               dataset: parameters.dataset,
-              filter: getFilter(parameters, defaultPointmapSamplingDayRange, parameters.geoIds),
+              filter: getFilter(parameters, defaultPointmapSamplingDayRange),
               select: {
                 order: ["-create_at"],
                 limit: defaultPointmapLimit,

--- a/examples/twittermap/web/public/javascripts/map/controllers.js
+++ b/examples/twittermap/web/public/javascripts/map/controllers.js
@@ -10,7 +10,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
           cleanPointMap();
           setCountMapStyle();
           setInfoControlCountMap();
-          cloudberry.query(cloudberry.parameters, cloudberry.queryType);
+          cloudberry.query(cloudberry.parameters);
           break;
 
         case 'heatmap':
@@ -20,7 +20,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
           cleanCountMap();
           setPointMapStyle();
           setInfoControlPointMap();
-          cloudberry.query(cloudberry.parameters, cloudberry.queryType);
+          cloudberry.query(cloudberry.parameters);
           break;
 
         default:
@@ -551,6 +551,9 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
             loadCityJsonByBound(onEachFeature);
           } else if ($scope.status.zoomLevel > 5) {
             resetGeoInfo("county");
+            if (!$scope.status.init) {
+              cloudberry.query(cloudberry.parameters, false);
+            }
             if ($scope.polygons.statePolygons) {
               $scope.map.removeLayer($scope.polygons.statePolygons);
             }
@@ -564,6 +567,9 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
             $scope.map.addLayer($scope.polygons.countyPolygons);
           } else if ($scope.status.zoomLevel <= 5) {
             resetGeoInfo("state");
+            if (!$scope.status.init) {
+              cloudberry.query(cloudberry.parameters, false);
+            }
             if ($scope.polygons.countyPolygons) {
               $scope.map.removeLayer($scope.polygons.countyPolygons);
             }
@@ -609,8 +615,11 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
         }
         if ($scope.status.logicLevel === 'city') {
             loadCityJsonByBound(onEachFeature, false);
+        } else {
+          resetGeoIds($scope.bounds, geoData, $scope.status.logicLevel + "ID");
+          cloudberry.parameters.geoLevel = $scope.status.logicLevel;
+          cloudberry.query(cloudberry.parameters, false);
         }
-        resetGeoIds($scope.bounds, geoData, $scope.status.logicLevel + "ID");
       });
 
       $scope.mouseOverPointI = 0;

--- a/examples/twittermap/web/public/javascripts/map/controllers.js
+++ b/examples/twittermap/web/public/javascripts/map/controllers.js
@@ -402,9 +402,11 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
 
       loadGeoJsonFiles(onEachFeature);
 
+      // remove original zoomfunction associated with zoom event
       if ($scope.zoomfunction) {
         $scope.zoomfunction()
       }
+      // add new zoomfunction
       $scope.zoomfunction = $scope.$on("leafletDirectiveMap.zoomend", function() {
         if ($scope.map) {
           $scope.status.zoomLevel = $scope.map.getZoom();
@@ -462,9 +464,11 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
         }
       });
 
+      // remove original dragfunction associated with drag event
       if ($scope.dragfunction) {
         $scope.dragfunction()
       }
+      // add new dragfunction
       $scope.dragfunction = $scope.$on("leafletDirectiveMap.dragend", function() {
         if (!$scope.status.init) {
           $scope.bounds = $scope.map.getBounds();

--- a/examples/twittermap/web/public/javascripts/map/controllers.js
+++ b/examples/twittermap/web/public/javascripts/map/controllers.js
@@ -8,6 +8,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
       switch (cloudberry.parameters.maptype) {
         case 'countmap':
           cleanPointMap();
+          setCountMapStyle();
           setInfoControlCountMap();
           cloudberry.query(cloudberry.parameters, cloudberry.queryType);
           break;
@@ -17,6 +18,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
 
         case 'pointmap':
           cleanCountMap();
+          setPointMapStyle();
           setInfoControlPointMap();
           cloudberry.query(cloudberry.parameters, cloudberry.queryType);
           break;
@@ -185,28 +187,139 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
           break;
       }
     };
-
-    function removePolygonLayers() {
+    
+    function resetPolygonLayers() {
       if ($scope.polygons.statePolygons) {
-        $scope.map.removeLayer($scope.polygons.statePolygons);
+        //$scope.map.removeLayer($scope.polygons.statePolygons);
+        $scope.polygons.statePolygons.setStyle($scope.styles.stateStyle);
       }
       if ($scope.polygons.countyPolygons) {
-        $scope.map.removeLayer($scope.polygons.countyPolygons);
+        //$scope.map.removeLayer($scope.polygons.countyPolygons);
+        $scope.polygons.countyPolygons.setStyle($scope.styles.countyStyle);
       }
       if ($scope.polygons.cityPolygons) {
-        $scope.map.removeLayer($scope.polygons.cityPolygons);
+        //$scope.map.removeLayer($scope.polygons.cityPolygons);
+        $scope.polygons.cityPolygons.setStyle($scope.styles.cityStyle);
       }
       if ($scope.polygons.stateUpperPolygons) {
-        $scope.map.removeLayer($scope.polygons.stateUpperPolygons);
+        //$scope.map.removeLayer($scope.polygons.stateUpperPolygons);
+        $scope.polygons.stateUpperPolygons.setStyle($scope.styles.stateUpperStyle);
       }
       if ($scope.polygons.countyUpperPolygons) {
-        $scope.map.removeLayer($scope.polygons.countyUpperPolygons);
+        //$scope.map.removeLayer($scope.polygons.countyUpperPolygons);
+        $scope.polygons.countyUpperPolygons.setStyle($scope.styles.countyUpperStyle);
       }
+    }
+    
+    function setCountMapStyle() {
+      $scope.styles = {
+        initStyle: {
+          weight: 1.5,
+          fillOpacity: 0.5,
+          color: 'white'
+        },
+        stateStyle: {
+          fillColor: '#f7f7f7',
+          weight: 1.5,
+          opacity: 1,
+          color: '#92d1e1',
+          fillOpacity: 0.5
+        },
+        stateUpperStyle: {
+          fillColor: '#f7f7f7',
+          weight: 1.5,
+          opacity: 1,
+          color: '#92d1e1',
+          fillOpacity: 0.5
+        },
+        countyStyle: {
+          fillColor: '#f7f7f7',
+          weight: 1.5,
+          opacity: 1,
+          color: '#92d1e1',
+          fillOpacity: 0.5
+        },
+        countyUpperStyle: {
+          fillColor: '#f7f7f7',
+          weight: 1.5,
+          opacity: 1,
+          color: '#92d1e1',
+          fillOpacity: 0.5
+        },
+        cityStyle: {
+          fillColor: '#f7f7f7',
+          weight: 1.5,
+          opacity: 1,
+          color: '#92d1e1',
+          fillOpacity: 0.5
+        },
+        hoverStyle: {
+          weight: 5,
+          color: '#666',
+          fillOpacity: 0.5
+        },
+        colors: [ '#ffffff', '#92d1e1', '#4393c3', '#2166ac', '#f4a582', '#d6604d', '#b2182b'],
+        sentimentColors: ['#ff0000', '#C0C0C0', '#00ff00']
+      };
+      
+      resetPolygonLayers();
+    }
+    
+    function setPointMapStyle() {
+      $scope.styles = {
+        initStyle: {
+          weight: 0.5,
+          fillOpacity: 0,
+          color: 'white'
+        },
+        stateStyle: {
+          fillColor: '#f7f7f7',
+          weight: 0.5,
+          opacity: 1,
+          color: '#92d1e1',
+          fillOpacity: 0
+        },
+        stateUpperStyle: {
+          fillColor: '#f7f7f7',
+          weight: 0.5,
+          opacity: 1,
+          color: '#92d1e1',
+          fillOpacity: 0
+        },
+        countyStyle: {
+          fillColor: '#f7f7f7',
+          weight: 0.5,
+          opacity: 1,
+          color: '#92d1e1',
+          fillOpacity: 0
+        },
+        countyUpperStyle: {
+          fillColor: '#f7f7f7',
+          weight: 0.5,
+          opacity: 1,
+          color: '#92d1e1',
+          fillOpacity: 0
+        },
+        cityStyle: {
+          fillColor: '#f7f7f7',
+          weight: 0.5,
+          opacity: 1,
+          color: '#92d1e1',
+          fillOpacity: 0
+        },
+        hoverStyle: {
+          weight: 0.7,
+          color: '#666',
+          fillOpacity: 0
+        },
+        colors: [ '#ffffff', '#92d1e1', '#4393c3', '#2166ac', '#f4a582', '#d6604d', '#b2182b'],
+        sentimentColors: ['#ff0000', '#C0C0C0', '#00ff00']
+      };
+      
+      resetPolygonLayers();
     }
 
     function cleanCountMap() {
-
-      removePolygonLayers();
 
       function removeMapControl(name){
         var ctrlClass = $("."+name);
@@ -390,110 +503,9 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
         $scope.map.removeLayer($scope.currentMarker);
         $scope.currentMarker = null;
       }
-      $scope.styles = {
-        initStyle: {
-          weight: 1.5,
-          fillOpacity: 0.5,
-          color: 'white'
-        },
-        stateStyle: {
-          fillColor: '#f7f7f7',
-          weight: 1.5,
-          opacity: 1,
-          color: '#92d1e1',
-          fillOpacity: 0.5
-        },
-        stateUpperStyle: {
-          fillColor: '#f7f7f7',
-          weight: 1.5,
-          opacity: 1,
-          color: '#92d1e1',
-          fillOpacity: 0.5
-        },
-        countyStyle: {
-          fillColor: '#f7f7f7',
-          weight: 1.5,
-          opacity: 1,
-          color: '#92d1e1',
-          fillOpacity: 0.5
-        },
-        countyUpperStyle: {
-          fillColor: '#f7f7f7',
-          weight: 1.5,
-          opacity: 1,
-          color: '#92d1e1',
-          fillOpacity: 0.5
-        },
-        cityStyle: {
-          fillColor: '#f7f7f7',
-          weight: 1.5,
-          opacity: 1,
-          color: '#92d1e1',
-          fillOpacity: 0.5
-        },
-        hoverStyle: {
-          weight: 5,
-          color: '#666',
-          fillOpacity: 0.5
-        },
-        colors: [ '#ffffff', '#92d1e1', '#4393c3', '#2166ac', '#f4a582', '#d6604d', '#b2182b'],
-        sentimentColors: ['#ff0000', '#C0C0C0', '#00ff00']
-      };
-
-      removePolygonLayers();
     }
 
     function setInfoControlPointMap() {
-      //change the style of the polygons
-      $scope.styles = {
-        initStyle: {
-          weight: 0.5,
-          fillOpacity: 0,
-          color: 'white'
-        },
-        stateStyle: {
-          fillColor: '#f7f7f7',
-          weight: 0.5,
-          opacity: 1,
-          color: '#92d1e1',
-          fillOpacity: 0
-        },
-        stateUpperStyle: {
-          fillColor: '#f7f7f7',
-          weight: 0.5,
-          opacity: 1,
-          color: '#92d1e1',
-          fillOpacity: 0
-        },
-        countyStyle: {
-          fillColor: '#f7f7f7',
-          weight: 0.5,
-          opacity: 1,
-          color: '#92d1e1',
-          fillOpacity: 0
-        },
-        countyUpperStyle: {
-          fillColor: '#f7f7f7',
-          weight: 0.5,
-          opacity: 1,
-          color: '#92d1e1',
-          fillOpacity: 0
-        },
-        cityStyle: {
-          fillColor: '#f7f7f7',
-          weight: 0.5,
-          opacity: 1,
-          color: '#92d1e1',
-          fillOpacity: 0
-        },
-        hoverStyle: {
-          weight: 0.7,
-          color: '#666',
-          fillOpacity: 0
-        },
-        colors: [ '#ffffff', '#92d1e1', '#4393c3', '#2166ac', '#f4a582', '#d6604d', '#b2182b'],
-        sentimentColors: ['#ff0000', '#C0C0C0', '#00ff00']
-      };
 
       function zoomToFeature(leafletEvent) {
           if (leafletEvent)
@@ -629,7 +641,8 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
     }
     // load geoJson
     function loadGeoJsonFiles(onEachFeature) {
-      $http.get("assets/data/state.json")
+      if ($scope.polygons.statePolygons == null){
+        $http.get("assets/data/state.json")
         .success(function(data) {
           $scope.geojsonData.state = data;
           $scope.polygons.statePolygons = L.geoJson(data, {
@@ -651,7 +664,9 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
         .error(function(data) {
           console.error("Load state data failure");
         });
-      $http.get("assets/data/county.json")
+      }
+      if ($scope.polygons.countyPolygons == null){
+        $http.get("assets/data/county.json")
         .success(function(data) {
           $scope.geojsonData.county = data;
           $scope.polygons.countyPolygons = L.geoJson(data, {
@@ -674,6 +689,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
         .error(function(data) {
           console.error("Load county data failure");
         });
+      }
     }
 
     function loadCityJsonByBound(onEachFeature){

--- a/examples/twittermap/web/public/javascripts/map/controllers.js
+++ b/examples/twittermap/web/public/javascripts/map/controllers.js
@@ -190,23 +190,18 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
     
     function resetPolygonLayers() {
       if ($scope.polygons.statePolygons) {
-        //$scope.map.removeLayer($scope.polygons.statePolygons);
         $scope.polygons.statePolygons.setStyle($scope.styles.stateStyle);
       }
       if ($scope.polygons.countyPolygons) {
-        //$scope.map.removeLayer($scope.polygons.countyPolygons);
         $scope.polygons.countyPolygons.setStyle($scope.styles.countyStyle);
       }
       if ($scope.polygons.cityPolygons) {
-        //$scope.map.removeLayer($scope.polygons.cityPolygons);
         $scope.polygons.cityPolygons.setStyle($scope.styles.cityStyle);
       }
       if ($scope.polygons.stateUpperPolygons) {
-        //$scope.map.removeLayer($scope.polygons.stateUpperPolygons);
         $scope.polygons.stateUpperPolygons.setStyle($scope.styles.stateUpperStyle);
       }
       if ($scope.polygons.countyUpperPolygons) {
-        //$scope.map.removeLayer($scope.polygons.countyUpperPolygons);
         $scope.polygons.countyUpperPolygons.setStyle($scope.styles.countyUpperStyle);
       }
     }
@@ -338,30 +333,34 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
     function setInfoControlCountMap() {
       // Interaction function
       function highlightFeature(leafletEvent) {
-        var layer = leafletEvent.target;
-        layer.setStyle($scope.styles.hoverStyle);
-        if (!L.Browser.ie && !L.Browser.opera) {
-          layer.bringToFront();
+        if (cloudberry.parameters.maptype == 'countmap'){
+          var layer = leafletEvent.target;
+          layer.setStyle($scope.styles.hoverStyle);
+          if (!L.Browser.ie && !L.Browser.opera) {
+            layer.bringToFront();
+          }
+          $scope.selectedPlace = layer.feature;
         }
-        $scope.selectedPlace = layer.feature;
       }
 
       function resetHighlight(leafletEvent) {
-        var style;
-        if (!$scope.status.init)
-          style = {
-            weight: 1.5,
-            fillOpacity: 0.5,
-            color: '#92d1e1'
-          };
-        else
-          style = {
-            weight: 1.5,
-            fillOpacity: 0.5,
-            color: '#92d1e1'
-          };
-        if (leafletEvent)
-          leafletEvent.target.setStyle(style);
+        if (cloudberry.parameters.maptype == 'countmap'){
+          var style;
+          if (!$scope.status.init)
+            style = {
+              weight: 1.5,
+              fillOpacity: 0.5,
+              color: '#92d1e1'
+            };
+          else
+            style = {
+              weight: 1.5,
+              fillOpacity: 0.5,
+              color: '#92d1e1'
+            };
+          if (leafletEvent)
+            leafletEvent.target.setStyle(style);
+        }
       }
 
       function zoomToFeature(leafletEvent) {
@@ -399,11 +398,11 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
       $scope.controls.custom.push(info);
 
       loadGeoJsonFiles(onEachFeature);
-      if ($scope.status.logicLevel === "city"){
-        loadCityJsonByBound(onEachFeature);
-      }
 
-      $scope.$on("leafletDirectiveMap.zoomend", function() {
+      if ($scope.zoomfunction) {
+        $scope.zoomfunction()
+      }
+      $scope.zoomfunction = $scope.$on("leafletDirectiveMap.zoomend", function() {
         if ($scope.map) {
           $scope.status.zoomLevel = $scope.map.getZoom();
           $scope.bounds = $scope.map.getBounds();
@@ -460,7 +459,10 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
         }
       });
 
-      $scope.$on("leafletDirectiveMap.dragend", function() {
+      if ($scope.dragfunction) {
+        $scope.dragfunction()
+      }
+      $scope.dragfunction = $scope.$on("leafletDirectiveMap.dragend", function() {
         if (!$scope.status.init) {
           $scope.bounds = $scope.map.getBounds();
           var geoData;
@@ -519,14 +521,10 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
       }
 
       loadGeoJsonFiles(onEachFeature);
-      if ($scope.status.logicLevel === "city"){
-        loadCityJsonByBound(onEachFeature);
-      }
-
+      
       if ($scope.zoomfunction) {
         $scope.zoomfunction()
       }
-
       $scope.zoomfunction = $scope.$on("leafletDirectiveMap.zoomend", function () {
         if ($scope.map) {
           $scope.status.zoomLevel = $scope.map.getZoom();
@@ -653,13 +651,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
             style: $scope.styles.stateUpperStyle
           });
           setCenterAndBoundry($scope.geojsonData.state.features);
-          if ($scope.status.logicLevel === 'state'){
-            $scope.polygons.statePolygons.addTo($scope.map);
-            if (cloudberry.parameters.maptype === "countmap"){
-              cloudberry.parameters.geoLevel = $scope.status.logicLevel;
-              cloudberry.query(cloudberry.parameters);
-            }
-          }
+          $scope.polygons.statePolygons.addTo($scope.map);
         })
         .error(function(data) {
           console.error("Load state data failure");
@@ -677,14 +669,6 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
             style: $scope.styles.countyUpperStyle
           });
           setCenterAndBoundry($scope.geojsonData.county.features);
-          if ($scope.status.logicLevel === 'county'){
-            $scope.map.addLayer($scope.polygons.stateUpperPolygons);
-            $scope.map.addLayer($scope.polygons.countyPolygons);
-            if (cloudberry.parameters.maptype === "countmap"){
-              cloudberry.parameters.geoLevel = $scope.status.logicLevel;
-              cloudberry.query(cloudberry.parameters);
-            }
-          }
         })
         .error(function(data) {
           console.error("Load county data failure");

--- a/examples/twittermap/web/public/javascripts/map/controllers.js
+++ b/examples/twittermap/web/public/javascripts/map/controllers.js
@@ -706,7 +706,12 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
                 if (!$scope.status.init) {
                     resetGeoIds($scope.bounds, data, 'cityID');
                     cloudberry.parameters.geoLevel = 'city';
-                    cloudberry.query(cloudberry.parameters);
+                    if (cloudberry.parameters.maptype === 'pointmap'){
+                      cloudberry.query(cloudberry.parameters, false);
+                    }
+                    else {
+                      cloudberry.query(cloudberry.parameters);
+                    }
                 }
 
                 $scope.status.logicLevel = 'city';
@@ -756,7 +761,12 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
                     setCenterAndBoundry($scope.geojsonData.city.features);
                     resetGeoInfo("city");
                     if (!$scope.status.init) {
+                      if (cloudberry.parameters.maptype === 'pointmap'){
+                        cloudberry.query(cloudberry.parameters, false);
+                      }
+                      else {
                         cloudberry.query(cloudberry.parameters);
+                      }
                     }
                     $scope.map.addLayer($scope.polygons.cityPolygons);
                 })

--- a/examples/twittermap/web/public/javascripts/map/controllers.js
+++ b/examples/twittermap/web/public/javascripts/map/controllers.js
@@ -346,20 +346,23 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
       function resetHighlight(leafletEvent) {
         if (cloudberry.parameters.maptype == 'countmap'){
           var style;
-          if (!$scope.status.init)
+          if (!$scope.status.init){
             style = {
               weight: 1.5,
               fillOpacity: 0.5,
               color: '#92d1e1'
             };
-          else
+          }
+          else {
             style = {
               weight: 1.5,
               fillOpacity: 0.5,
               color: '#92d1e1'
             };
-          if (leafletEvent)
+          }
+          if (leafletEvent){
             leafletEvent.target.setStyle(style);
+          }
         }
       }
 
@@ -639,7 +642,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
     }
     // load geoJson
     function loadGeoJsonFiles(onEachFeature) {
-      if ($scope.polygons.statePolygons == null){
+      if (typeof($scope.polygons.statePolygons) === "undefined" || $scope.polygons.statePolygons == null){
         $http.get("assets/data/state.json")
         .success(function(data) {
           $scope.geojsonData.state = data;
@@ -657,7 +660,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
           console.error("Load state data failure");
         });
       }
-      if ($scope.polygons.countyPolygons == null){
+      if (typeof($scope.polygons.countyPolygons) === "undefined" || $scope.polygons.countyPolygons == null){
         $http.get("assets/data/county.json")
         .success(function(data) {
           $scope.geojsonData.county = data;


### PR DESCRIPTION
A quick fix to time series and tweet count issues in pointmap.
1. Modified getFilter: if the geoIds argument is undefined, then the filter is disabled.
2. Added an argument "getPoints" to query(). If getPoints is false, only send time series query to update the tweet count and time series.
3. Fixed loadCityJsonByBound() so it will only send time series queries in pointmap