### PR TITLE
Add "id" and "category" parameter to replace current "key" parameter of Query API

### DIFF
--- a/cloudberry/neo/app/actor/RequestRouter.scala
+++ b/cloudberry/neo/app/actor/RequestRouter.scala
@@ -4,7 +4,7 @@ import akka.actor.{Actor, ActorLogging, Props}
 import akka.stream.Materializer
 import edu.uci.ics.cloudberry.zion.actor.BerryClient._
 import edu.uci.ics.cloudberry.zion.common.Config
-import edu.uci.ics.cloudberry.zion.model.datastore.{IPostTransform, NoTransform}
+import edu.uci.ics.cloudberry.zion.model.datastore.{ICategoricalTransform, IPostTransform, NoTransform}
 import play.api.libs.json._
 import play.api.Logger
 import play.api.mvc.RequestHeader
@@ -57,7 +57,7 @@ object RequestRouter {
   def props(berryClientProp: Props, config: Config, requestHeader: RequestHeader)
            (implicit ec: ExecutionContext, materializer: Materializer) = Props(new RequestRouter(berryClientProp, config, requestHeader))
 
-  case class WrapTransform(id: String, category: String) extends IPostTransform {
+  case class WrapTransform(id: String, category: String) extends ICategoricalTransform{
     override def transform(jsonBody: JsValue): JsValue = {
       Json.obj("id" -> id, "category" -> category, "value" -> jsonBody)
     }

--- a/cloudberry/neo/app/actor/RequestRouter.scala
+++ b/cloudberry/neo/app/actor/RequestRouter.scala
@@ -36,7 +36,7 @@ class RequestRouter (berryClientProp: Props, config: Config, requestHeader: Requ
     (requestBody \ "transform").asOpt[JsValue] match {
       case Some(t) =>
         (t \ "wrap").asOpt[JsValue] match {
-          case Some(w) => WrapTransform((w \"key").as[String])
+          case Some(w) => WrapTransform((w \"id").as[String], (w \"category").as[String])
           case None => NoTransform
         }
       case None => NoTransform
@@ -57,9 +57,9 @@ object RequestRouter {
   def props(berryClientProp: Props, config: Config, requestHeader: RequestHeader)
            (implicit ec: ExecutionContext, materializer: Materializer) = Props(new RequestRouter(berryClientProp, config, requestHeader))
 
-  case class WrapTransform(key: String) extends IPostTransform {
+  case class WrapTransform(id: String, category: String) extends IPostTransform {
     override def transform(jsonBody: JsValue): JsValue = {
-      Json.obj("key" -> key, "value" -> jsonBody)
+      Json.obj("id" -> id, "category" -> category, "value" -> jsonBody)
     }
   }
 

--- a/cloudberry/neo/test/actor/RequestRouterTest.scala
+++ b/cloudberry/neo/test/actor/RequestRouterTest.scala
@@ -41,7 +41,7 @@ class RequestRouterTest extends TestkitExample with SpecificationLike with Mocki
           |  },
           |  "transform":{
           |    "wrap":{
-          |      "id": "sample_test"
+          |      "id": "sample_test",
           |      "category": "sample"
           |    }
           |  }
@@ -74,7 +74,7 @@ class RequestRouterTest extends TestkitExample with SpecificationLike with Mocki
           |  },
           |  "transform":{
           |    "wrap":{
-          |      "id": "batch_test"
+          |      "id": "batch_test",
           |      "category": "batch"
           |    }
           |  }

--- a/cloudberry/neo/test/actor/RequestRouterTest.scala
+++ b/cloudberry/neo/test/actor/RequestRouterTest.scala
@@ -41,7 +41,8 @@ class RequestRouterTest extends TestkitExample with SpecificationLike with Mocki
           |  },
           |  "transform":{
           |    "wrap":{
-          |      "key": "sample"
+          |      "id": "sample_test"
+          |      "category": "sample"
           |    }
           |  }
           |}
@@ -73,7 +74,8 @@ class RequestRouterTest extends TestkitExample with SpecificationLike with Mocki
           |  },
           |  "transform":{
           |    "wrap":{
-          |      "key": "batch"
+          |      "id": "batch_test"
+          |      "category": "batch"
           |    }
           |  }
           |}

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
@@ -67,8 +67,8 @@ class BerryClient(val jsonParser: JSONParser,
         //TODO Ultimately, clients can run multiple streaming request simultaneously.
         //     They can also cancel or reset a specific request.
         //     Right now, we are just allow one streaming request at once, the later one will stop the previous running request.
-        val child = context.child(transform.category).getOrElse(
-          context.actorOf(Props(new ProgressiveSolver(dataManager, planner, config, out)), transform.category)
+        val child = context.child("stream").getOrElse(
+          context.actorOf(Props(new ProgressiveSolver(dataManager, planner, config, out)), "stream")
         )
         child ! ProgressiveSolver.Cancel // Cancel ongoing slicing work if any
         child ! ProgressiveSolver.SlicingRequest(paceMS, resultSizeLimit, queries, mapInfos, transform)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
@@ -67,8 +67,8 @@ class BerryClient(val jsonParser: JSONParser,
         //TODO Ultimately, clients can run multiple streaming request simultaneously.
         //     They can also cancel or reset a specific request.
         //     Right now, we are just allow one streaming request at once, the later one will stop the previous running request.
-        val child = context.child("stream").getOrElse(
-          context.actorOf(Props(new ProgressiveSolver(dataManager, planner, config, out)), "stream")
+        val child = context.child(transform.category).getOrElse(
+          context.actorOf(Props(new ProgressiveSolver(dataManager, planner, config, out)), transform.category)
         )
         child ! ProgressiveSolver.Cancel // Cancel ongoing slicing work if any
         child ! ProgressiveSolver.SlicingRequest(paceMS, resultSizeLimit, queries, mapInfos, transform)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/datastore/IPostTransform.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/datastore/IPostTransform.scala
@@ -4,12 +4,14 @@ import play.api.libs.json.JsValue
 
 
 trait IPostTransform {
-  def category: String
   def transform(jsValue: JsValue): JsValue
 }
 
+trait ICategoricalTransform extends IPostTransform{
+  def category: String
+}
+
 case object NoTransform extends IPostTransform {
-  override def category: String = "default"
   override def transform(jsValue: JsValue): JsValue = jsValue
 }
 

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/datastore/IPostTransform.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/datastore/IPostTransform.scala
@@ -4,10 +4,12 @@ import play.api.libs.json.JsValue
 
 
 trait IPostTransform {
+  def category: String
   def transform(jsValue: JsValue): JsValue
 }
 
 case object NoTransform extends IPostTransform {
+  override def category: String = "default"
   override def transform(jsValue: JsValue): JsValue = jsValue
 }
 

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -67,7 +67,8 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
       estimable : true,
       transform: {
         wrap: {
-          key: "totalCount"
+          id: "totalCount",
+          category: "totalCount"
         }
       }
     });
@@ -290,7 +291,8 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
               },
               transform: {
                 wrap: {
-                  key: "sample"
+                  id: "sample",
+                  category: "sample"
                 }
               }
             }));
@@ -303,14 +305,16 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
               },
               transform: {
                 wrap: {
-                  key: "batchWithoutGeoRequest"
+                  id: "batchWithoutGeoRequest",
+                  category: "batchWithoutGeoRequest"
                 }
               }
             })) : (JSON.stringify({
                 batch: [byTimeRequest(parameters), byHashTagRequest(parameters)],
                 transform: {
                     wrap: {
-                        key: "batchWithoutGeoRequest"
+                        id: "batchWithoutGeoRequest",
+                        category: "batchWithoutGeoRequest"
                     }
                 }
             }));
@@ -330,7 +334,8 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
               },
               transform: {
                 wrap: {
-                  key: "batchWithPartialGeoRequest"
+                  id: "batchWithPartialGeoRequest",
+                  category: "batchWithPartialGeoRequest"
                 }
               }
             })) : (JSON.stringify({
@@ -338,7 +343,8 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
                     byHashTagRequest(parameters)],
                 transform: {
                     wrap: {
-                        key: "batchWithPartialGeoRequest"
+                        id: "batchWithPartialGeoRequest",
+                        category: "batchWithPartialGeoRequest"
                     }
                 }
             }));
@@ -377,7 +383,8 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
               },
               transform: {
                 wrap: {
-                  key: "points"
+                  id: "points",
+                  category: "points"
                 }
               }
             }));
@@ -410,7 +417,8 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
               },
               transform: {
                 wrap: {
-                  key: "pointsTime"
+                  id: "pointsTime",
+                  category: "pointsTime"
                 }
               }
             }));
@@ -430,7 +438,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
       $timeout(function() {
         var result = JSONbig.parse(event.data);
 
-        switch (result.key) {
+        switch (result.category) {
 
           case "sample":
             cloudberryService.tweetResult = result.value[0];


### PR DESCRIPTION
Issue #467 
**Problem:**
    Previously, Cloudberry Query API was designed with a keyword called "transform", and inside it there is one function called "wrap" implemented. The purpose of "wrap" it to wrap the result into a package and identify it with a "key". Therefore, "key" has been used by the Frontend user (i.e. TwitterMap) as an request ID to identify the result belongs to which query it sent. However, as issue #463 indicates, now we need not only a request ID to identify a query, but also a query "category" as an unique name for our backend server to create proper number of actors solving queries.

**Solution:**
    Here comes the solution, we use 2 parameters inside the "wrap" function of keyword "transform", namely "id" and "category". The "id" serves as an identification of each query and its corresponding result. The "category" serves as a classification of each query for the Cloudberry to schedule its resources more properly.