### PR TITLE
Create a stream actor for each "category" query

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
@@ -5,7 +5,7 @@ import akka.pattern.ask
 import akka.util.Timeout
 import edu.uci.ics.cloudberry.zion.actor.DataStoreManager.AskInfo
 import edu.uci.ics.cloudberry.zion.common.Config
-import edu.uci.ics.cloudberry.zion.model.datastore.{IPostTransform, JsonRequestException, NoTransform}
+import edu.uci.ics.cloudberry.zion.model.datastore.{ICategoricalTransform, IPostTransform, JsonRequestException, NoTransform}
 import edu.uci.ics.cloudberry.zion.model.impl.{DataSetInfo, JSONParser, QueryPlanner}
 import play.api.libs.json._
 
@@ -63,12 +63,14 @@ class BerryClient(val jsonParser: JSONParser,
           // TODO send error messages to user
           throw JsonRequestException("Batch Requests cannot contain \"limit\" field")
         }
-        //Each streaming request need a specific actor to handle the request.
-        //TODO Ultimately, clients can run multiple streaming request simultaneously.
-        //     They can also cancel or reset a specific request.
-        //     Right now, we are just allow one streaming request at once, the later one will stop the previous running request.
-        val child = context.child("stream").getOrElse(
-          context.actorOf(Props(new ProgressiveSolver(dataManager, planner, config, out)), "stream")
+        //Right now, we create one stream actor for one 'category' query indicated by 'transform'->'wrap'->'category'.
+        //TODO Clients can also cancel or reset a specific request.
+        var streamActorName = "default"
+        if (transform.isInstanceOf[ICategoricalTransform]) {
+          streamActorName = transform.asInstanceOf[ICategoricalTransform].category
+        }
+        val child = context.child(streamActorName).getOrElse(
+          context.actorOf(Props(new ProgressiveSolver(dataManager, planner, config, out)), streamActorName)
         )
         child ! ProgressiveSolver.Cancel // Cancel ongoing slicing work if any
         child ! ProgressiveSolver.SlicingRequest(paceMS, resultSizeLimit, queries, mapInfos, transform)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/BerryClient.scala
@@ -65,12 +65,12 @@ class BerryClient(val jsonParser: JSONParser,
         }
         //Right now, we create one stream actor for one 'category' query indicated by 'transform'->'wrap'->'category'.
         //TODO Clients can also cancel or reset a specific request.
-        var streamActorName = "default"
-        if (transform.isInstanceOf[ICategoricalTransform]) {
-          streamActorName = transform.asInstanceOf[ICategoricalTransform].category
+        val actorName = transform match{
+          case categorical: ICategoricalTransform => categorical.category
+          case _ => "default"
         }
-        val child = context.child(streamActorName).getOrElse(
-          context.actorOf(Props(new ProgressiveSolver(dataManager, planner, config, out)), streamActorName)
+        val child = context.child(actorName).getOrElse(
+          context.actorOf(Props(new ProgressiveSolver(dataManager, planner, config, out)), actorName)
         )
         child ! ProgressiveSolver.Cancel // Cancel ongoing slicing work if any
         child ! ProgressiveSolver.SlicingRequest(paceMS, resultSizeLimit, queries, mapInfos, transform)


### PR DESCRIPTION
#463 
**Problem:** 
    Currently, `berryClient` only creates two downstream actors, one actor for non-slicing queries and the other actor (named `stream`) for slicing queries.  The problem is it will not allow any frontend user to send two different `category`s of slicing queries simultaneously, because the single `stream` actor will drop any previous slicing queries once it receives a new slicing query.

**Solution:**
    Change the logic of creating slicing-query actor to creating one actor which will be named with the value of `category` parameter inside the query's `transform` keyword, therefore, for each different `category` query, there will be one actor solving it.