### PR TITLE
Make parameters of Pointmap configurable

### DIFF
--- a/examples/twittermap/web/app/controllers/TwitterMapApplication.scala
+++ b/examples/twittermap/web/app/controllers/TwitterMapApplication.scala
@@ -37,6 +37,8 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   val cities: List[JsValue] = TwitterMapApplication.loadCity(environment.getFile(USCityDataPath))
   val cacheThreshold : Option[String] = config.getString("cacheThreshold")
   val querySliceMills: Option[String] = config.getString("querySliceMills")
+  val pointmapSamplingDayRange: String = config.getString("pointmap.samplingDayRange").getOrElse("30")
+  val pointmapSamplingLimit: String = config.getString("pointmap.samplingLimit").getOrElse("5000")
 
   val webSocketFactory = new WebSocketFactory()
   val clientLogger = Logger("client")
@@ -55,7 +57,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
     val remoteAddress = request.remoteAddress
     val userAgent = request.headers.get("user-agent").getOrElse("unknown")
     clientLogger.info(s"Connected: user_IP_address = $remoteAddress; user_agent = $userAgent")
-    Ok(views.html.twittermap.index("TwitterMap", startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, cacheThreshold, querySliceMills, false, sqlDB))
+    Ok(views.html.twittermap.index("TwitterMap", startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, cacheThreshold, querySliceMills, false, sqlDB, pointmapSamplingDayRange, pointmapSamplingDayRange))
   }
 
   def drugmap = Action {
@@ -64,7 +66,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
       val remoteAddress = request.remoteAddress
       val userAgent = request.headers.get("user-agent").getOrElse("unknown")
       clientLogger.info(s"Connected: user_IP_address = $remoteAddress; user_agent = $userAgent")
-      Ok(views.html.twittermap.index("DrugMap", startDateDrugMap, endDate, false, sentimentUDF, true, Seq("drug"), cacheThreshold, querySliceMills, true, sqlDB))
+      Ok(views.html.twittermap.index("DrugMap", startDateDrugMap, endDate, false, sentimentUDF, true, Seq("drug"), cacheThreshold, querySliceMills, true, sqlDB, pointmapSamplingDayRange, pointmapSamplingDayRange))
   }
 
   def ws = WebSocket.accept[JsValue, JsValue] { request =>

--- a/examples/twittermap/web/app/views/twittermap/index.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/index.scala.html
@@ -1,6 +1,6 @@
 
 @import controllers.TwitterMapApplication.DBType
-@(title: String, startDate: String, endDate:Option[String], sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], cacheThreshold: Option[String], querySliceMills: Option[String], isDrugMap: Boolean, sqlDB: DBType.Value) @main(title, startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, cacheThreshold, querySliceMills, isDrugMap, sqlDB){
+@(title: String, startDate: String, endDate:Option[String], sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], cacheThreshold: Option[String], querySliceMills: Option[String], isDrugMap: Boolean, sqlDB: DBType.Value, pointmapSamplingDayRange: String, pointmapSamplingLimit: String) @main(title, startDate, endDate, sentimentEnabled, sentimentUDF, removeSearchBar, predefinedKeywords, cacheThreshold, querySliceMills, isDrugMap, sqlDB, pointmapSamplingDayRange, pointmapSamplingLimit){
 <div xmlns="http://www.w3.org/1999/html" ng-controller="AppCtrl">
 
   <div class="map-group">

--- a/examples/twittermap/web/app/views/twittermap/main.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/main.scala.html
@@ -1,5 +1,5 @@
 @import controllers.TwitterMapApplication.DBType
-@(title: String, startDate: String, endDate: Option[String], sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], cacheThreshold: Option[String], querySliceMills: Option[String], isDrugMap: Boolean, sqlDB: DBType.Value)(body: Html)
+@(title: String, startDate: String, endDate: Option[String], sentimentEnabled: Boolean, sentimentUDF: String, removeSearchBar: Boolean, predefinedKeywords: Seq[String], cacheThreshold: Option[String], querySliceMills: Option[String], isDrugMap: Boolean, sqlDB: DBType.Value, pointmapSamplingDayRange: String, pointmapSamplingLimit: String)(body: Html)
 
 @import play.api.libs.json.Json
 
@@ -47,9 +47,10 @@
       querySliceMills: @querySliceMills,
       } else {
       // The default query slicing milliseconds value
-      querySliceMills: new String("2000")
+      querySliceMills: new String("2000"),
       }
-
+      pointmapSamplingDayRange: @pointmapSamplingDayRange,
+      pointmapSamplingLimit: @pointmapSamplingLimit
     }
   </script>
   <script src='@routes.Assets.versioned("lib/angularjs/angular.min.js")'></script>

--- a/examples/twittermap/web/conf/application.conf
+++ b/examples/twittermap/web/conf/application.conf
@@ -116,5 +116,7 @@ us.city.path = "/public/data/city.sample.json"
 tweet.url = "http://twitterMapIndex-search-proxy.herokuapp.com/search/tweets?q=%s"
 
 # Pointmap parameters
-pointmap.samplingDayRange = 30
-pointmap.samplingLimit = 5000
+# How many recent days of the time range predicate of each pointmap query.
+# pointmap.samplingDayRange = 30
+# How many tweets at most returned for each pointmap query.
+# pointmap.samplingLimit = 5000

--- a/examples/twittermap/web/conf/application.conf
+++ b/examples/twittermap/web/conf/application.conf
@@ -115,3 +115,6 @@ us.city.path = "/public/data/city.sample.json"
 
 tweet.url = "http://twitterMapIndex-search-proxy.herokuapp.com/search/tweets?q=%s"
 
+# Pointmap parameters
+pointmap.samplingDayRange = 30
+pointmap.samplingLimit = 5000

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -47,8 +47,8 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
     var defaultNonSamplingDayRange = 1500;
     var defaultSamplingDayRange = 1;
     var defaultSamplingSize = 10;
-    var defaultPointmapSamplingDayRange = 7;
-    var defaultPointmapLimit = 25*1000;
+    var defaultPointmapSamplingDayRange = parseInt(config.pointmapSamplingDayRange);
+    var defaultPointmapLimit = parseInt(config.pointmapSamplingLimit);
     var ws = new WebSocket(cloudberryConfig.ws);
     // The MapResultCache.getGeoIdsNotInCache() method returns the geoIds
     // not in the cache for the current query.


### PR DESCRIPTION
Before enabling Pointmap in our production system, @chenlica suggests that we tune the two parameters: sampling time range which is `pointmapSamplingDayRange` and returned result records limit which is `pointmapSamplingLimit` both on Backup server and Production server to make the user experience more reasonable.

This PR is to make these 2 parameters configurable in the `application.conf ` file of Twittermap.