### PR TITLE
Aggressive drum reporter

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/Reporter.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/Reporter.scala
@@ -27,9 +27,7 @@ class Reporter(out: ActorRef)(implicit val ec: ExecutionContext) extends Actor w
         timer.cancel()
         context.become(hungry(DateTime.now()), discardOld = false)
       } else {
-        //val result = queue.dequeue()
-        //out ! Json.toJson(result.content)
-        var result = queue.dequeueAll(_ => true)
+        val result = queue.dequeueAll(_ => true)
         out ! Json.toJson(result.last.content)
       }
     }

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/Reporter.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/Reporter.scala
@@ -27,8 +27,10 @@ class Reporter(out: ActorRef)(implicit val ec: ExecutionContext) extends Actor w
         timer.cancel()
         context.become(hungry(DateTime.now()), discardOld = false)
       } else {
-        val result = queue.dequeue()
-        out ! Json.toJson(result.content)
+        //val result = queue.dequeue()
+        //out ! Json.toJson(result.content)
+        var result = queue.dequeueAll(_ => true)
+        out ! Json.toJson(result.last.content)
       }
     }
     case any =>


### PR DESCRIPTION
* Previously, every time when it reaches deadline for reporting result, the `reporter` only dequeue one partial result of one mini query to return to the client.
* Currently, every time when it reaches deadline for reporting result, the `reporter` will empty the partial result queue and return them all.