### PR TITLE
Disable create views in RESTSolver and Tune alpha to be more aggressive

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -62,7 +62,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
       val queryGroup = QueryGroup(ts, queryInfos, request.postTransform)
       val initResult = Seq.fill(queryInfos.size)(JsArray())
       issueQueryGroup(interval, queryGroup)
-      val drumEstimator = new Drum(boundary.toDuration.getStandardHours.toInt, alpha = 1, initialDuration.toHours.toInt)
+      val drumEstimator = new Drum(boundary.toDuration.getStandardHours.toInt, alpha = 0.00001, initialDuration.toHours.toInt)
       context.become(askSlice(request.resultSizeLimitOpt, request.intervalMS, request.intervalMS, interval, drumEstimator, Int.MaxValue, boundary, queryGroup, initResult, issuedTimestamp = DateTime.now), discardOld = true)
     case _: MiniQueryResult =>
       // do nothing

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTSolver.scala
@@ -26,6 +26,7 @@ class RESTSolver(val dataManager: ActorRef,
       val futureResult = Future.traverse(queries)(q => solveAQuery(q)).map(JsArray.apply)
       futureResult.map(result => (queries, result)).foreach { case (qs, r) =>
         out ! transform.transform(r)
+        //Disabled this suggest views to avoid competing resources in DB with ongoing ProgressiveSolver.
         //qs.foreach(suggestViews)
       }
   }

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTSolver.scala
@@ -26,7 +26,7 @@ class RESTSolver(val dataManager: ActorRef,
       val futureResult = Future.traverse(queries)(q => solveAQuery(q)).map(JsArray.apply)
       futureResult.map(result => (queries, result)).foreach { case (qs, r) =>
         out ! transform.transform(r)
-        qs.foreach(suggestViews)
+        //qs.foreach(suggestViews)
       }
   }
 

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTSolver.scala
@@ -27,6 +27,7 @@ class RESTSolver(val dataManager: ActorRef,
       futureResult.map(result => (queries, result)).foreach { case (qs, r) =>
         out ! transform.transform(r)
         //Disabled this suggest views to avoid competing resources in DB with ongoing ProgressiveSolver.
+        //TODO Once we have view management mechanism, could use a common service to request a view creation.
         //qs.foreach(suggestViews)
       }
   }

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/SimpleBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/SimpleBerryClientTest.scala
@@ -59,9 +59,10 @@ class SimpleBerryClientTest extends TestkitExample with SpecificationLike with M
 
       sender.expectMsg(JsArray(Seq(JsArray(Seq(Json.obj("a" -> 4), Json.obj("b" -> 8))))))
 
-      dataManager.expectMsg(DataStoreManager.AskInfoAndViews(query.dataset))
-      dataManager.reply(Seq(sourceInfo))
-      dataManager.expectMsg(create)
+      //Disabled this suggest views in RESTSolver.
+      //dataManager.expectMsg(DataStoreManager.AskInfoAndViews(query.dataset))
+      //dataManager.reply(Seq(sourceInfo))
+      //dataManager.expectMsg(create)
       ok
     }
     "send the NoSuchData msg if the request is on a unknown dataset" in {


### PR DESCRIPTION
**Disable create views in RESTSolver**
Currently, when Twittermap sends 2 concurrent queries to Cloudberry, one being batch query handled by ProgressiveSolver with slicing and the other being single query handled by RESTSolver without slicing. The latter will be finished very soon and create views in AsterixDB while ProgressiveSolver is still running and accessing the same part of data in AsterixDB, then the creating views operation will compete resources with ongoing mini queries to slow them down. This PR will `disable` this `views creation` operation in `RESTSolver` when non-slicing queries finish to avoid this problem.

**Tune alpha to be more aggressive**
Our observation shows that current Drum behavior in production system with 1.2 billion tweets is too `conservative` on uniformly distributed keywords, therefore, this PR also modifies the `Alpha` parameter of `Drum` from `1.0` to `0.00001` to be much more `aggressive`, so that the power of AsterixDB can be fully utilized.