### PR TITLE
Fix bug: conf berry.query.gap is never used in Drum

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -58,12 +58,12 @@ class ProgressiveSolver(val dataManager: ActorRef,
       val boundary = new TInterval(min, max)
 
       val initialDuration = config.FirstQueryTimeGap
-      val minDuration = config.MinTimeGap
+      val minimumDuration = config.MinTimeGap
       val interval = calculateFirst(boundary, initialDuration)
       val queryGroup = QueryGroup(ts, queryInfos, request.postTransform)
       val initResult = Seq.fill(queryInfos.size)(JsArray())
       issueQueryGroup(interval, queryGroup)
-      val drumEstimator = new Drum(boundary.toDuration.getStandardHours.toInt, alpha = 0.00001, minDuration.toHours.toInt)
+      val drumEstimator = new Drum(boundary.toDuration.getStandardHours.toInt, alpha = 0.00001, minimumDuration.toHours.toInt)
       context.become(askSlice(request.resultSizeLimitOpt, request.intervalMS, request.intervalMS, interval, drumEstimator, Int.MaxValue, boundary, queryGroup, initResult, issuedTimestamp = DateTime.now), discardOld = true)
     case _: MiniQueryResult =>
       // do nothing

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -58,11 +58,12 @@ class ProgressiveSolver(val dataManager: ActorRef,
       val boundary = new TInterval(min, max)
 
       val initialDuration = config.FirstQueryTimeGap
+      val minDuration = config.MinTimeGap
       val interval = calculateFirst(boundary, initialDuration)
       val queryGroup = QueryGroup(ts, queryInfos, request.postTransform)
       val initResult = Seq.fill(queryInfos.size)(JsArray())
       issueQueryGroup(interval, queryGroup)
-      val drumEstimator = new Drum(boundary.toDuration.getStandardHours.toInt, alpha = 0.00001, initialDuration.toHours.toInt)
+      val drumEstimator = new Drum(boundary.toDuration.getStandardHours.toInt, alpha = 0.00001, minDuration.toHours.toInt)
       context.become(askSlice(request.resultSizeLimitOpt, request.intervalMS, request.intervalMS, interval, drumEstimator, Int.MaxValue, boundary, queryGroup, initResult, issuedTimestamp = DateTime.now), discardOld = true)
     case _: MiniQueryResult =>
       // do nothing


### PR DESCRIPTION
**Bug**
Previously, the `ProgressiveSolver` will `initialize` a `Drum` instance with the parameter `minRange` assigned value from `berry.firstquery.gap` in conf file. But the `berry.query.gap` parameter never used.

**Solution**
In `ProgressiveSolver`, load the `berry.query.gap` value from conf file and initialize `Drum` instance with `minRange` assigned by that value.