### PR TITLE
[issue#513] Time-series caching part#3

### DIFF
--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -301,8 +301,6 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
       countmapMapResult: [],
       countmapPartialMapResult: [],
       commonTimeSeriesResult: [],
-      // storage for the subset of time-series result in TimeSeriesCache, with format {day, count}.
-      timeSeriesPartialResult: [],
       // storage for the newest byTimeSeries query result, with format {geoId, day, count}.
       timeSeriesQueryResult: [],
       commonHashTagResult: [],
@@ -317,8 +315,6 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
         // and retrieve cached time-series data from the cache for the current user request.
         geoIdsNotInTimeSeriesCache = TimeSeriesCache.getGeoIdsNotInCache(parameters.keywords,
           parameters.timeInterval, parameters.geoIds, parameters.geoLevel);
-        cloudberryService.timeSeriesPartialResult = TimeSeriesCache.getTimeSeriesValues(parameters.geoIds,
-            parameters.geoLevel, parameters.timeInterval);
 
         // generate query based on map type
         switch (parameters.maptype) {
@@ -549,7 +545,12 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
               cloudberryService.timeSeriesQueryResult = result.value[0];
               // Avoid memory leak.
               result.value[0] = [];
-              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.timeSeriesQueryResult).concat(cloudberryService.timeSeriesPartialResult);
+              var requestTimeRange = {
+                start: new Date(result.timeInterval.start),
+                end: new Date(result.timeInterval.end)
+              }
+              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.timeSeriesQueryResult).concat(
+                TimeSeriesCache.getTimeSeriesValues(cloudberryService.parameters.geoIds, cloudberryService.parameters.geoLevel, requestTimeRange));
               cloudberryService.commonHashTagResult = result.value[1];
             }
             // When the query is executed completely, we update the time-series cache's time interval.
@@ -566,7 +567,12 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
               cloudberryService.timeSeriesQueryResult = result.value[0];
               // Avoid memory leak.
               result.value[0] = [];
-              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.timeSeriesQueryResult).concat(cloudberryService.timeSeriesPartialResult);
+              var requestTimeRange = {
+                start: new Date(result.timeInterval.start),
+                end: new Date(result.timeInterval.end)
+              }
+              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.timeSeriesQueryResult).concat(
+                TimeSeriesCache.getTimeSeriesValues(cloudberryService.parameters.geoIds, cloudberryService.parameters.geoLevel, requestTimeRange));
               cloudberryService.countmapMapResult = result.value[1].concat(cloudberryService.countmapPartialMapResult);
               cloudberryService.commonHashTagResult = result.value[2];
             }
@@ -595,7 +601,12 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
               cloudberryService.timeSeriesQueryResult = result.value[0];
               // Avoid memory leak.
               result.value[0] = [];
-              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.timeSeriesQueryResult).concat(cloudberryService.timeSeriesPartialResult);
+              var requestTimeRange = {
+                start: new Date(result.timeInterval.start),
+                end: new Date(result.timeInterval.end)
+              }
+              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.timeSeriesQueryResult).concat(
+               TimeSeriesCache.getTimeSeriesValues(cloudberryService.parameters.geoIds, cloudberryService.parameters.geoLevel, requestTimeRange));
             }
             // When the query is executed completely, we update the time-series cache's time interval.
             if((cloudberryConfig.querySliceMills > 0 && !angular.isArray(result.value) &&
@@ -616,7 +627,12 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
               cloudberryService.timeSeriesQueryResult = result.value[0];
               // Avoid memory leak.
               result.value[0] = [];
-              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.timeSeriesQueryResult).concat(cloudberryService.timeSeriesPartialResult);
+              var requestTimeRange = {
+                start: new Date(result.timeInterval.start),
+                end: new Date(result.timeInterval.end)
+              }
+              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.timeSeriesQueryResult).concat(
+               TimeSeriesCache.getTimeSeriesValues(cloudberryService.parameters.geoIds, cloudberryService.parameters.geoLevel, requestTimeRange));
             }
             // When the query is executed completely, we update the time-series cache's time interval.
             if((cloudberryConfig.querySliceMills > 0 && !angular.isArray(result.value) &&

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -1,4 +1,4 @@
-angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
+angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.timeseriescache'])
   .factory('cloudberryConfig', function(){
     return {
       ws: "ws://" + location.host + "/ws",
@@ -41,7 +41,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
       }
     };
   })
-  .service('cloudberry', function($timeout, cloudberryConfig, MapResultCache) {
+  .service('cloudberry', function($timeout, cloudberryConfig, MapResultCache, TimeSeriesCache) {
     var startDate = config.startDate;
     var endDate = config.endDate;
     var defaultNonSamplingDayRange = 1500;
@@ -55,6 +55,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
     // The MapResultCache.getGeoIdsNotInCache() method returns the geoIds
     // not in the cache for the current query.
     var geoIdsNotInCache = [];
+    var geoIdsNotInTimeSeriesCache = [];
 
     var countRequest = JSON.stringify({
       dataset: "twitter.ds_tweet",
@@ -199,10 +200,10 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
       }
     }
 
-    function byTimeRequest(parameters) {
+    function byTimeRequest(parameters, geoIds) {
       return {
         dataset: parameters.dataset,
-        filter: getFilter(parameters, defaultNonSamplingDayRange, parameters.geoIds),
+        filter: getFilter(parameters, defaultNonSamplingDayRange, geoIds),
         group: {
           by: [{
             field: "geo",
@@ -237,7 +238,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
 
     // Handle byTimeRequest in heatmap and pinmap.
     function handleByTimeRequest(parameters, categoryName) {
-      var byTimeRequestquery = byTimeRequest(parameters);
+      var byTimeRequestquery = byTimeRequest(parameters, geoIdsNotInTimeSeriesCache);
       byTimeRequestquery['option'] = {
         sliceMillis: cloudberryConfig.querySliceMills
       };
@@ -279,41 +280,6 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
       };
     }
 
-    // Retrieves time-series histogram result from the byTimeRequest result.
-    function getTimeSeriesValues(byTimeRequestResult) {
-      const INVALID_VALUE = 0;
-
-      var timeSeriesStore = new HashMap();
-      var geoIdSet = new Set(cloudberryService.parameters.geoIds);
-      for (var i = 0; i < byTimeRequestResult.length; i++) {
-        var currVal = byTimeRequestResult[i];
-        var geoIds = currVal[cloudberryService.parameters.geoLevel];
-        var values = timeSeriesStore.get(geoIds);
-        // First updates the store with geoIds that have results.
-        if (values !== undefined && values !== INVALID_VALUE) { // when one geoIds has more than one value
-          values.push({day:currVal["day"], count:currVal["count"]});
-          timeSeriesStore.set(geoIds, values);
-          geoIdSet.delete(currVal[cloudberryService.parameters.geoLevel]);
-        } else { // first value of current geoId
-          timeSeriesStore.set(geoIds, [{day:currVal["day"], count:currVal["count"]}]);
-          geoIdSet.delete(currVal[cloudberryService.parameters.geoLevel]);
-        }
-      }
-      // Mark other results as checked: these are geoIds with no results
-      geoIdSet.forEach(function (value) {
-        timeSeriesStore.set(value, INVALID_VALUE);
-      });
-
-      var timeSeriesResultArray = [];
-      for (var j = 0; j < cloudberryService.parameters.geoIds.length; j++) {
-        var value = timeSeriesStore.get(cloudberryService.parameters.geoIds[j]);
-        if (value !== undefined && value !== INVALID_VALUE) {
-          timeSeriesResultArray = timeSeriesResultArray.concat(value);
-        }
-      }
-      return timeSeriesResultArray;
-    }
-
     var cloudberryService = {
 
       commonTotalCount: 0,
@@ -333,6 +299,8 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
       countmapMapResult: [],
       countmapPartialMapResult: [],
       commonTimeSeriesResult: [],
+      cachedTimeSeriesResult: [],
+      byTimeSeriesResult: [],
       commonHashTagResult: [],
       errorMessage: null,
 
@@ -340,6 +308,12 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
       
         if (ws.readyState !== ws.OPEN || typeof(parameters.keywords) === "undefined" || parameters.keywords == null || parameters.keywords.length == 0)
           return;
+
+        // for time-series histogram
+        geoIdsNotInTimeSeriesCache = TimeSeriesCache.getGeoIdsNotInCache(parameters.keywords,
+          parameters.timeInterval, parameters.geoIds, parameters.geoLevel);
+        cloudberryService.cachedTimeSeriesResult = TimeSeriesCache.getTimeSeriesValues(parameters.geoIds,
+            parameters.geoLevel, parameters.timeInterval);
 
         // generate query based on map type
         switch (parameters.maptype) {
@@ -363,7 +337,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
 
             // Batch request without map result - used when the complete map result cache hit case
             var batchWithoutGeoRequest = cloudberryConfig.querySliceMills > 0 ? (JSON.stringify({
-              batch: [byTimeRequest(parameters), byHashTagRequest(parameters)],
+              batch: [byTimeRequest(parameters, geoIdsNotInTimeSeriesCache), byHashTagRequest(parameters)],
               option: {
                 sliceMillis: cloudberryConfig.querySliceMills
               },
@@ -374,7 +348,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
                 }
               }
             })) : (JSON.stringify({
-                batch: [byTimeRequest(parameters), byHashTagRequest(parameters)],
+                batch: [byTimeRequest(parameters, geoIdsNotInTimeSeriesCache), byHashTagRequest(parameters)],
                 transform: {
                     wrap: {
                         id: "batchWithoutGeoRequest",
@@ -391,7 +365,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
             // Batch request with only the geoIds whose map result are not cached yet - partial map result cache hit case
             // This case also covers the complete cache miss case.
             var batchWithPartialGeoRequest = cloudberryConfig.querySliceMills > 0 ? (JSON.stringify({
-              batch: [byTimeRequest(parameters), byGeoRequest(parameters, geoIdsNotInCache),
+              batch: [byTimeRequest(parameters, geoIdsNotInTimeSeriesCache), byGeoRequest(parameters, geoIdsNotInCache),
                 byHashTagRequest(parameters)],
               option: {
                 sliceMillis: cloudberryConfig.querySliceMills
@@ -403,7 +377,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
                 }
               }
             })) : (JSON.stringify({
-                batch: [byTimeRequest(parameters), byGeoRequest(parameters, geoIdsNotInCache),
+                batch: [byTimeRequest(parameters, geoIdsNotInTimeSeriesCache), byGeoRequest(parameters, geoIdsNotInCache),
                   byHashTagRequest(parameters)],
                 transform: {
                     wrap: {
@@ -565,22 +539,33 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
           // Complete cache hit case
           case "batchWithoutGeoRequest":
             if(angular.isArray(result.value)) {
-              cloudberryService.commonTimeSeriesResult = getTimeSeriesValues(result.value[0]);
+              cloudberryService.byTimeSeriesResult = result.value[0];
+              // avoid memory leak.
+              result.value[0] = [];
+              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.byTimeSeriesResult).concat(cloudberryService.cachedTimeSeriesResult);
               cloudberryService.commonHashTagResult = result.value[1];
+            }
+            // When the query is executed completely, we update the time-series cache's time interval.
+            if((cloudberryConfig.querySliceMills > 0 && !angular.isArray(result.value) &&
+                result.value['key'] === "done") || cloudberryConfig.querySliceMills <= 0) {
+              TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.byTimeSeriesResult);
             }
             break;
           // Partial map result cache hit or complete cache miss case
           case "batchWithPartialGeoRequest":
             if(angular.isArray(result.value)) {
-              cloudberryService.commonTimeSeriesResult = getTimeSeriesValues(result.value[0]);
+              cloudberryService.byTimeSeriesResult = result.value[0];
+              result.value[0] = [];
+              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.byTimeSeriesResult).concat(cloudberryService.cachedTimeSeriesResult);
               cloudberryService.countmapMapResult = result.value[1].concat(cloudberryService.countmapPartialMapResult);
               cloudberryService.commonHashTagResult = result.value[2];
             }
-            // When the query is executed completely, we update the map result cache.
+            // When the query is executed completely, we update the map result cache and time-series cache's time interval.
             if((cloudberryConfig.querySliceMills > 0 && !angular.isArray(result.value) &&
                 result.value['key'] === "done") || cloudberryConfig.querySliceMills <= 0) {
               MapResultCache.putValues(geoIdsNotInCache, cloudberryService.parameters.geoLevel,
                 cloudberryService.countmapMapResult);
+                TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.byTimeSeriesResult);
             }
             break;
           case "batchHeatMapRequest":
@@ -595,7 +580,14 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
             break;
           case "heatTime":
             if(angular.isArray(result.value)) {
-              cloudberryService.commonTimeSeriesResult = getTimeSeriesValues(result.value[0]);
+              cloudberryService.byTimeSeriesResult = result.value[0];
+              result.value[0] = [];
+              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.byTimeSeriesResult).concat(cloudberryService.cachedTimeSeriesResult);
+            }
+            // When the query is executed completely, we update the time-series cache's time interval.
+            if((cloudberryConfig.querySliceMills > 0 && !angular.isArray(result.value) &&
+                result.value['key'] === "done") || cloudberryConfig.querySliceMills <= 0) {
+              TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.byTimeSeriesResult);
             }
             break;
           case "points":
@@ -606,7 +598,14 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
             break;
           case "pointsTime":
             if(angular.isArray(result.value)) {
-              cloudberryService.commonTimeSeriesResult = getTimeSeriesValues(result.value[0]);
+              cloudberryService.byTimeSeriesResult = result.value[0];
+              result.value[0] = [];
+              cloudberryService.commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(cloudberryService.byTimeSeriesResult).concat(cloudberryService.cachedTimeSeriesResult);
+            }
+            // When the query is executed completely, we update the time-series cache's time interval.
+            if((cloudberryConfig.querySliceMills > 0 && !angular.isArray(result.value) &&
+                result.value['key'] === "done") || cloudberryConfig.querySliceMills <= 0) {
+              TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.byTimeSeriesResult);
             }
             break;
           case "hashTags":

--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -555,7 +555,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
             // When the query is executed completely, we update the time-series cache's time interval.
             if((cloudberryConfig.querySliceMills > 0 && !angular.isArray(result.value) &&
                 result.value['key'] === "done") || cloudberryConfig.querySliceMills <= 0) {
-              TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.timeSeriesQueryResult);
+              TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.timeSeriesQueryResult, cloudberryService.parameters.timeInterval);
             }
             break;
           // Partial map result cache hit or complete cache miss case
@@ -575,7 +575,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
                 result.value['key'] === "done") || cloudberryConfig.querySliceMills <= 0) {
               MapResultCache.putValues(geoIdsNotInCache, cloudberryService.parameters.geoLevel,
                 cloudberryService.countmapMapResult);
-                TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.timeSeriesQueryResult);
+                TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.timeSeriesQueryResult, cloudberryService.parameters.timeInterval);
             }
             break;
           case "batchHeatMapRequest":
@@ -600,7 +600,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
             // When the query is executed completely, we update the time-series cache's time interval.
             if((cloudberryConfig.querySliceMills > 0 && !angular.isArray(result.value) &&
                 result.value['key'] === "done") || cloudberryConfig.querySliceMills <= 0) {
-              TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.timeSeriesQueryResult);
+              TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.timeSeriesQueryResult, cloudberryService.parameters.timeInterval);
             }
             break;
           case "points":
@@ -621,7 +621,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
             // When the query is executed completely, we update the time-series cache's time interval.
             if((cloudberryConfig.querySliceMills > 0 && !angular.isArray(result.value) &&
                 result.value['key'] === "done") || cloudberryConfig.querySliceMills <= 0) {
-              TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.timeSeriesQueryResult);
+              TimeSeriesCache.putTimeSeriesValues(geoIdsNotInTimeSeriesCache, cloudberryService.timeSeriesQueryResult, cloudberryService.parameters.timeInterval);
             }
             break;
           case "hashTags":

--- a/examples/twittermap/web/public/javascripts/timeseriescache/services.js
+++ b/examples/twittermap/web/public/javascripts/timeseriescache/services.js
@@ -71,6 +71,7 @@ angular.module('cloudberry.timeseriescache', [])
                     }
                 }
             }
+
             return resultArray;
         };
 
@@ -83,6 +84,7 @@ angular.module('cloudberry.timeseriescache', [])
                 var currVal = {day:timeseriesResult[i]["day"], count:timeseriesResult[i]["count"]};
                 resultArray.push(currVal);
             }
+
             return resultArray;
         }
 
@@ -118,11 +120,18 @@ angular.module('cloudberry.timeseriescache', [])
          * Updates the store with time-series result each time the middleware responds to the json request preloadRequest,
          * returns histogram data.
          */
-        this.putTimeSeriesValues = function (geoIds, timeseriesResult) {
+        this.putTimeSeriesValues = function (geoIds, timeseriesResult, timeInterval) {
             // In case of cache miss.
             if (geoIds.length !== 0) {
                 var store = this.arrayToStore(geoIds, timeseriesResult);
-                timeseriesStore = store;
+                if (timeseriesStore.count() == 0) {
+                    timeseriesStore = store;
+                } else if (timeInterval.start.getTime() == cachedTimeRange.start.getTime() &&
+                           timeInterval.end.getTime() == cachedTimeRange.end.getTime()) {
+                    store.forEach(function(value, key) {timeseriesStore.set(key, value)});
+                } else {
+                    // Result is not added to cache because it has a shorter time interval than older cached results.
+                }
             }
         };
     });

--- a/examples/twittermap/web/public/javascripts/timeseriescache/services.js
+++ b/examples/twittermap/web/public/javascripts/timeseriescache/services.js
@@ -38,8 +38,7 @@ angular.module('cloudberry.timeseriescache', [])
             if (keywords.toString() != currentKeywords.toString() ||
                 timeInterval.start < cachedTimeRange.start ||
                 timeInterval.end > cachedTimeRange.end ||
-                geoLevel != currentGeoLevel ||
-                timeseriesStore.count() > MAX_GEOIDS) {
+                geoLevel != currentGeoLevel) {
                 timeseriesStore.clear();
                 currentKeywords = keywords.slice();
                 currentGeoLevel = geoLevel;
@@ -52,6 +51,11 @@ angular.module('cloudberry.timeseriescache', [])
                 if (!timeseriesStore.has(geoIds[i])) {
                     geoIdsNotInCache.push(geoIds[i]);
                 }
+            }
+            // Clear storage if caching the new query will exceed MAX_GEOIDS limit.
+            if (timeseriesStore.count() + geoIdsNotInCache.length > MAX_GEOIDS) {
+                timeseriesStore.clear();
+                return geoIds;
             }
 
             return geoIdsNotInCache;

--- a/examples/twittermap/web/public/javascripts/timeseriescache/services.js
+++ b/examples/twittermap/web/public/javascripts/timeseriescache/services.js
@@ -22,6 +22,8 @@ angular.module('cloudberry.timeseriescache', [])
             end: endDate
         };
         const INVALID_VALUE = 0;
+        // Maximum geoIds in cache, to avoid reaching mamximum browser memory capacity.
+        const MAX_GEOIDS = 3222;
 
         /**
          * Checks keyword, time range and the cache store, and returns the geoIds that
@@ -36,7 +38,8 @@ angular.module('cloudberry.timeseriescache', [])
             if (keywords.toString() != currentKeywords.toString() ||
                 timeInterval.start < cachedTimeRange.start ||
                 timeInterval.end > cachedTimeRange.end ||
-                geoLevel != currentGeoLevel) {
+                geoLevel != currentGeoLevel ||
+                timeseriesStore.count() > MAX_GEOIDS) {
                 timeseriesStore.clear();
                 currentKeywords = keywords.slice();
                 currentGeoLevel = geoLevel;
@@ -120,6 +123,7 @@ angular.module('cloudberry.timeseriescache', [])
          * Updates the store with time-series result each time the middleware responds to the json request preloadRequest,
          * returns histogram data.
          */
+        // TODO: combine geoIds and timeInterval dimensions in the time-series and map-rsult cache modules.
         this.putTimeSeriesValues = function (geoIds, timeseriesResult, timeInterval) {
             // In case of cache miss.
             if (geoIds.length !== 0) {


### PR DESCRIPTION
Part#1: `PR#525 [issue#513] Time-series caching part#1`
Modify byTimeRequest and merge query results to generate timeseries.

________
Part#2: `PR#542 [issue#513] Time-series caching part#2`
Introduce timeseriescache module, which includes the HashMap store and merge function.

________
Part#3: Utilize the time-series cache module in front-end logic.
- `common/services.js`
(i) Add `geoIdsNotInTimeSeriesCache` as a new parameter of `byTimeRequest()`.
(ii) Replace `getTimeSeriesValues()` with `TimeSeriesCache.getTimeSeriesValues()`.
(iii) Addition to the `cloudberryService Object`: 
-`timeSeriesQueryResult Array` stores the intermediate result (or complete result) after every middleware response. Format: [{geoID, day, count}, ...]. **Useful for the `popup-window feature`**.
-`timeSeriesPartialResult Array`, subset of historgram result in cache. Format: [{day, count}, ...].
-**`commonTimeSeriesResult = TimeSeriesCache.getValuesFromResult(timeSeriesQueryResult) + timeSeriesPartialResult`**, where `getValuesFromResult()` act as a format converter.

