### PR TITLE
[Issue #544] Hide/show Time series histogram with a new button

### DIFF
--- a/examples/twittermap/project/dependencies.scala
+++ b/examples/twittermap/project/dependencies.scala
@@ -67,7 +67,8 @@ object Dependencies {
     "org.webjars" % "font-awesome" % "4.5.0",
     "org.webjars.bower" % "bootstrap-vertical-tabs" % "1.2.1",
     // other module
-    "com.fasterxml.jackson.core" % "jackson-core" % "2.9.4"
+    "com.fasterxml.jackson.core" % "jackson-core" % "2.9.4",
+    "org.webjars.bower" % "jquery-ui" % "1.12.1"
 
   ) ++ testDeps
 }

--- a/examples/twittermap/project/dependencies.scala
+++ b/examples/twittermap/project/dependencies.scala
@@ -68,6 +68,7 @@ object Dependencies {
     "org.webjars.bower" % "bootstrap-vertical-tabs" % "1.2.1",
     // other module
     "com.fasterxml.jackson.core" % "jackson-core" % "2.9.4",
+    // Added jquery-ui for showing/hiding the time series histogram.
     "org.webjars.bower" % "jquery-ui" % "1.12.1"
 
   ) ++ testDeps

--- a/examples/twittermap/web/app/views/twittermap/index.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/index.scala.html
@@ -25,6 +25,7 @@
    <search-bar></search-bar>
    <predefined-keywords></predefined-keywords>
 
+   <!-- button for hide and show the timebar -->
   <div>
     <button type="button" class="btn btn-default btn-lg slide-up-down">
       <span id="downbutton" class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>
@@ -88,7 +89,8 @@
 }
 
 <script>
-
+  // Function for the button that hiding and showing the timebar. 
+  // The button moves together with timebar and the arrow direction changes. 
   $(document).ready(function() {
     $(".slide-up-down").click(function() {
       $(".stats").slideToggle();
@@ -102,5 +104,4 @@
       }
     });
   });
-
 </script>

--- a/examples/twittermap/web/app/views/twittermap/index.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/index.scala.html
@@ -25,6 +25,15 @@
    <search-bar></search-bar>
    <predefined-keywords></predefined-keywords>
 
+  <!-- modifiy hide and show button -->
+
+  <!-- <button type="button" class="slide-up-down">down</button> -->
+
+  <div>
+    <button type="button" class="btn btn-default btn-lg slide-up-down">
+      <span id="downbutton" class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>
+    </button>
+  </div>
 
 
   <div class="stats">
@@ -78,9 +87,24 @@
     <exception-bar></exception-bar>
   </div>
 
-
-
 </div>
 
-
 }
+
+<script>
+
+  $(document).ready(function() {
+    $(".slide-up-down").click(function() {
+      $(".stats").slideToggle();
+      if( $( 'button span' ).hasClass( 'glyphicon-menu-down' ) ) {
+        $( 'button span' ).removeClass( 'glyphicon-menu-down' ).addClass('glyphicon-menu-up');
+        $(this).animate({bottom: '5px'});
+      }
+      else {
+        $( 'button span' ).removeClass( 'glyphicon-menu-up').addClass( 'glyphicon-menu-down');
+        $(this).animate({bottom: '110px'}); 
+      }
+    });
+  });
+
+</script>

--- a/examples/twittermap/web/app/views/twittermap/index.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/index.scala.html
@@ -25,10 +25,6 @@
    <search-bar></search-bar>
    <predefined-keywords></predefined-keywords>
 
-  <!-- modifiy hide and show button -->
-
-  <!-- <button type="button" class="slide-up-down">down</button> -->
-
   <div>
     <button type="button" class="btn btn-default btn-lg slide-up-down">
       <span id="downbutton" class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>

--- a/examples/twittermap/web/app/views/twittermap/main.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/main.scala.html
@@ -83,8 +83,6 @@
   <script src='@routes.Assets.versioned("javascripts/lib/L.TileLayer.MaskCanvas.js")'></script>
   <script src='@routes.Assets.versioned("javascripts/lib/leaflet-heat.js")'></script>
   
-
-
   @if(isDrugMap) {
     <script src='@routes.Assets.versioned("javascripts/common/services-drug.js")'></script>
   }

--- a/examples/twittermap/web/app/views/twittermap/main.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/main.scala.html
@@ -69,6 +69,7 @@
   <script src='@routes.Assets.versioned("lib/dc.js/dc.min.js")'></script>
   <script src='@routes.Assets.versioned("lib/bootstrap/js/bootstrap.min.js")'></script>
   <script src='@routes.Assets.versioned("lib/bootstrap-toggle/js/bootstrap-toggle.min.js")'></script>
+  <script src='@routes.Assets.versioned("lib/jquery-ui/jquery-ui.js")'></script>
   <script src='@routes.Assets.versioned("javascripts/lib/rbush.min.js")'></script>
   <script src='@routes.Assets.versioned("javascripts/lib/turf.min.js")'></script>
   <script src='@routes.Assets.versioned("javascripts/app.js")'></script>
@@ -81,6 +82,8 @@
   <script src='@routes.Assets.versioned("javascripts/lib/QuadTree.js")'></script>
   <script src='@routes.Assets.versioned("javascripts/lib/L.TileLayer.MaskCanvas.js")'></script>
   <script src='@routes.Assets.versioned("javascripts/lib/leaflet-heat.js")'></script>
+  
+
 
   @if(isDrugMap) {
     <script src='@routes.Assets.versioned("javascripts/common/services-drug.js")'></script>

--- a/examples/twittermap/web/public/stylesheets/main.css
+++ b/examples/twittermap/web/public/stylesheets/main.css
@@ -119,7 +119,7 @@ search-bar {
 
 .stats{
   position: absolute;
-  bottom:0;
+  bottom: 0;
   pointer-events: none;
   line-height: 1;
   width: 100%;
@@ -223,3 +223,13 @@ time-series {
 
 .tweet-link:hover {
   text-decoration: underline; }
+
+.slide-up-down {
+  position: absolute;
+  display: inline-block;
+  width: 40px;
+  height: 34px;
+  bottom : 110px;
+  margin-left: 5px;
+}
+

--- a/examples/twittermap/web/public/stylesheets/main.css
+++ b/examples/twittermap/web/public/stylesheets/main.css
@@ -224,6 +224,7 @@ time-series {
 .tweet-link:hover {
   text-decoration: underline; }
 
+/* button for hiding and showing the timebar */
 .slide-up-down {
   position: absolute;
   display: inline-block;

--- a/examples/twittermap/web/public/stylesheets/main.css
+++ b/examples/twittermap/web/public/stylesheets/main.css
@@ -227,9 +227,11 @@ time-series {
 .slide-up-down {
   position: absolute;
   display: inline-block;
-  width: 40px;
-  height: 34px;
+  width: 53px;
+  height: 35px;
   bottom : 110px;
   margin-left: 5px;
 }
+
+
 


### PR DESCRIPTION
I introduced a new button on the map interface to hide/show the time series histogram.

_**examples/twittermap/web/app/views/twittermap/index.scala.html**_
1. Added a button div
2. Added a javascript code to hide/show the time series histogram and the number of tweets.

_**examples/twittermap/web/app/views/twittermap/main.scala.html**_
1. Added the jquery-ui library as a dependency.

**_examples/twittermap/web/public/stylesheets/main.css_**
1. Changed the appearance of the new button with css. (.slide-up-down)

Implementation: https://youtu.be/vwaKrJHOKt8

**Issue: #544** 


