### PR TITLE
[issue#557] Cloudberry carry time-interval with each sliced query result

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -108,9 +108,8 @@ class ProgressiveSolver(val dataManager: ActorRef,
         )
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
-        val timeIntervalValue = Json.toJson(timeInterval)
-        val results = timeIntervalValue ++ infoValue
-        val infoObject = Json.toJson(infoValue).as[JsObject]
+        val infoObject = infoValue.as[JsObject]
+        val results = Json.toJson(infoObject ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
@@ -134,9 +133,8 @@ class ProgressiveSolver(val dataManager: ActorRef,
         )
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
-        val timeIntervalValue = Json.toJson(timeInterval)
-        val results = timeIntervalValue ++ infoValue
-        val infoObject = Json.toJson(infoValue).as[JsObject]
+        val infoObject = infoValue.as[JsObject]
+        val results = Json.toJson(timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -99,15 +99,15 @@ class ProgressiveSolver(val dataManager: ActorRef,
         val limitResultOpt = resultSizeLimitOpt.map(limit => Seq(JsArray(mergedResults.head.value.take(limit))))
         val returnedResult = limitResultOpt.getOrElse(mergedResults)
 
-        val timeInterval: JsValue = JsObject(Seq(
+        val timeInterval = JsObject(Seq(
             "start" -> JsNumber(curInterval.getStart().getMillis()),
             "end" -> JsNumber(boundary.getEnd().getMillis())
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Json.toJson(Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval))
+        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval)
+log.debug(s"Jul31 1:35pm results ${results}")
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
-
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
 
         queryGroup.queries.foreach(qinfo => suggestViews(qinfo.query))
@@ -120,12 +120,13 @@ class ProgressiveSolver(val dataManager: ActorRef,
           curInterval.withEnd(boundary.getEnd).toDurationMillis.toDouble / boundary.toDurationMillis
         }
 
-        val timeInterval: JsValue = JsObject(Seq(
+        val timeInterval = JsObject(Seq(
             "start" -> JsNumber(curInterval.getStart().getMillis()),
             "end" -> JsNumber(boundary.getEnd().getMillis())
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Json.toJson(Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval))
+        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval)
+log.debug(s"Jul31 1:35pm results ${results}")
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -101,8 +101,8 @@ class ProgressiveSolver(val dataManager: ActorRef,
 
         val timeInterval: JsValue = JsObject(Seq(
             "timeInterval" -> JsObject(Seq(
-                "min" -> JsNumber(curInterval.getStart().getMillis()),
-                "max" -> JsNumber(boundary.getEnd().getMillis())
+                "start" -> JsNumber(curInterval.getStart().getMillis()),
+                "end" -> JsNumber(boundary.getEnd().getMillis())
             ))
         ))
         // for query with slicing request, add current timeInterval information in its query results.
@@ -124,8 +124,8 @@ class ProgressiveSolver(val dataManager: ActorRef,
 
         val timeInterval: JsValue = JsObject(Seq(
             "timeInterval" -> JsObject(Seq(
-                "min" -> JsNumber(curInterval.getStart().getMillis()),
-                "max" -> JsNumber(boundary.getEnd().getMillis())
+                "start" -> JsNumber(curInterval.getStart().getMillis()),
+                "end" -> JsNumber(boundary.getEnd().getMillis())
             ))
         ))
         // for query with slicing request, add current timeInterval information in its query results.

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -134,7 +134,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
         val infoObject = infoValue.asOpt[JsObject]
-        val results = Json.toJson(timeInterval)
+        val results = Json.toJson(infoObject ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -100,11 +100,13 @@ class ProgressiveSolver(val dataManager: ActorRef,
         val returnedResult = limitResultOpt.getOrElse(mergedResults)
 
         val timeInterval = JsObject(Seq(
-            "start" -> JsNumber(curInterval.getStart().getMillis()),
-            "end" -> JsNumber(boundary.getEnd().getMillis())
+            "timeInterval" -> JsObject(Seq(
+                "start" -> JsNumber(curInterval.getStart().getMillis()),
+                "end" -> JsNumber(boundary.getEnd().getMillis())
+            ))
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results : JsValue = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval)
+        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
@@ -120,11 +122,13 @@ class ProgressiveSolver(val dataManager: ActorRef,
         }
 
         val timeInterval = JsObject(Seq(
-            "start" -> JsNumber(curInterval.getStart().getMillis()),
-            "end" -> JsNumber(boundary.getEnd().getMillis())
+            "timeInterval" -> JsObject(Seq(
+                "start" -> JsNumber(curInterval.getStart().getMillis()),
+                "end" -> JsNumber(boundary.getEnd().getMillis())
+            ))
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results : JsValue = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval)
+        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -107,7 +107,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
           ) :: Nil
         )
         // for query with slicing request, add current timeInterval information in its query results.
-        val results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval
+        val results = Json.toJson(Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
@@ -130,7 +130,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
           ) :: Nil
         )
         // for query with slicing request, add current timeInterval information in its query results.
-        val results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval
+        val results = Json.toJson(Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -107,7 +107,9 @@ class ProgressiveSolver(val dataManager: ActorRef,
           ) :: Nil
         )
         // for query with slicing request, add current timeInterval information in its query results.
-        val results = Json.toJson(Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval)
+        val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
+        val infoObject = Json.toJson(infoValue).as[JsObject]
+        val results = Json.toJson(infoObject ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
@@ -130,7 +132,9 @@ class ProgressiveSolver(val dataManager: ActorRef,
           ) :: Nil
         )
         // for query with slicing request, add current timeInterval information in its query results.
-        val results = Json.toJson(Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval)
+        val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
+        val infoObject = Json.toJson(infoValue).as[JsObject]
+        val results = Json.toJson(infoObject ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -108,8 +108,9 @@ class ProgressiveSolver(val dataManager: ActorRef,
         )
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
+        val timeIntervalValue = Json.toJson(timeInterval)
+        val results = timeIntervalValue ++ infoValue
         val infoObject = Json.toJson(infoValue).as[JsObject]
-        val results = Json.toJson(infoObject ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
@@ -133,8 +134,9 @@ class ProgressiveSolver(val dataManager: ActorRef,
         )
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
+        val timeIntervalValue = Json.toJson(timeInterval)
+        val results = timeIntervalValue ++ infoValue
         val infoObject = Json.toJson(infoValue).as[JsObject]
-        val results = Json.toJson(infoObject ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -100,16 +100,13 @@ class ProgressiveSolver(val dataManager: ActorRef,
         val returnedResult = limitResultOpt.getOrElse(mergedResults)
 
         val timeInterval: JsValue = JsObject(Seq(
-            "timeInterval" -> JsObject(Seq(
-                "start" -> JsNumber(curInterval.getStart().getMillis()),
-                "end" -> JsNumber(boundary.getEnd().getMillis())
-            ))
+            "start" -> JsNumber(curInterval.getStart().getMillis()),
+            "end" -> JsNumber(boundary.getEnd().getMillis())
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Seq(Json.obj(queryGroup.postTransform.transform(JsArray(mergedResults))), Json.obj(timeInterval))
-        var jsonResults = results.foldLeft(Json.obj())((obj, a) => obj.deepMerge(a.as[JsObject]))
+        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval)
 
-        reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, jsonResults)
+        reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
 
         queryGroup.queries.foreach(qinfo => suggestViews(qinfo.query))
@@ -123,16 +120,13 @@ class ProgressiveSolver(val dataManager: ActorRef,
         }
 
         val timeInterval: JsValue = JsObject(Seq(
-            "timeInterval" -> JsObject(Seq(
-                "start" -> JsNumber(curInterval.getStart().getMillis()),
-                "end" -> JsNumber(boundary.getEnd().getMillis())
-            ))
+            "start" -> JsNumber(curInterval.getStart().getMillis()),
+            "end" -> JsNumber(boundary.getEnd().getMillis())
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Seq(Json.obj(queryGroup.postTransform.transform(JsArray(mergedResults))), Json.obj(timeInterval))
-        var jsonResults = results.foldLeft(Json.obj())((obj, a) => obj.deepMerge(a.as[JsObject]))
+        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval)
 
-        reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, jsonResults)
+        reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)
         context.become(askSlice(resultSizeLimitOpt, paceMS, nextLimit, nextInterval, estimator, nextEstimateMS, boundary, queryGroup, mergedResults, DateTime.now), discardOld = true)
       }

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -106,7 +106,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
             ))
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Seq(queryGroup.postTransform.transform(JsArray(mergedResults)), timeInterval)
+        var results = Seq(Json.obj(queryGroup.postTransform.transform(JsArray(mergedResults))), Json.obj(timeInterval))
         var jsonResults = results.foldLeft(Json.obj())((obj, a) => obj.deepMerge(a.as[JsObject]))
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, jsonResults)
@@ -129,7 +129,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
             ))
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Seq(queryGroup.postTransform.transform(JsArray(mergedResults)), timeInterval)
+        var results = Seq(Json.obj(queryGroup.postTransform.transform(JsArray(mergedResults))), Json.obj(timeInterval))
         var jsonResults = results.foldLeft(Json.obj())((obj, a) => obj.deepMerge(a.as[JsObject]))
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, jsonResults)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -145,7 +145,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
         }
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
-issueQueryGroup(nextInterval, queryGroup)
+        issueQueryGroup(nextInterval, queryGroup)
         context.become(askSlice(resultSizeLimitOpt, paceMS, nextLimit, nextInterval, estimator, nextEstimateMS, boundary, queryGroup, mergedResults, DateTime.now), discardOld = true)
       }
     case result: MiniQueryResult =>

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -99,12 +99,13 @@ class ProgressiveSolver(val dataManager: ActorRef,
         val limitResultOpt = resultSizeLimitOpt.map(limit => Seq(JsArray(mergedResults.head.value.take(limit))))
         val returnedResult = limitResultOpt.getOrElse(mergedResults)
 
-        val timeInterval = JsObject(Seq(
-            "timeInterval" -> JsObject(Seq(
-                "start" -> JsNumber(curInterval.getStart().getMillis()),
-                "end" -> JsNumber(boundary.getEnd().getMillis())
-            ))
-        ))
+        val timeInterval = JsObject(
+            "timeInterval" -> JsObject(
+                "start" -> JsNumber(curInterval.getStart().getMillis()) ::
+                "end" -> JsNumber(boundary.getEnd().getMillis()) ::
+            Nil
+            ) :: Nil
+        )
         // for query with slicing request, add current timeInterval information in its query results.
         var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval
 
@@ -121,12 +122,13 @@ class ProgressiveSolver(val dataManager: ActorRef,
           curInterval.withEnd(boundary.getEnd).toDurationMillis.toDouble / boundary.toDurationMillis
         }
 
-        val timeInterval = JsObject(Seq(
-            "timeInterval" -> JsObject(Seq(
-                "start" -> JsNumber(curInterval.getStart().getMillis()),
-                "end" -> JsNumber(boundary.getEnd().getMillis())
-            ))
-        ))
+        val timeInterval = JsObject(
+            "timeInterval" -> JsObject(
+                "start" -> JsNumber(curInterval.getStart().getMillis()) ::
+                "end" -> JsNumber(boundary.getEnd().getMillis()) ::
+                Nil
+            ) :: Nil
+        )
         // for query with slicing request, add current timeInterval information in its query results.
         var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval
 

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -109,7 +109,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
         val infoObject = infoValue.asOpt[JsObject]
-        val results = Json.toJson(infoObject ++ timeInterval)
+        val results = Json.toJson(infoObject ++ timeInterval.asOpt[JsObject])
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
@@ -134,7 +134,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
         val infoObject = infoValue.asOpt[JsObject]
-        val results = Json.toJson(infoObject ++ timeInterval)
+        val results = Json.toJson(infoObject ++ timeInterval.asOpt[JsObject])
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -100,14 +100,14 @@ class ProgressiveSolver(val dataManager: ActorRef,
         val returnedResult = limitResultOpt.getOrElse(mergedResults)
 
         val timeInterval = JsObject(
-            "timeInterval" -> JsObject(
-                "start" -> JsNumber(curInterval.getStart().getMillis()) ::
-                "end" -> JsNumber(boundary.getEnd().getMillis()) ::
+          "timeInterval" -> JsObject(
+            "start" -> JsNumber(curInterval.getStart().getMillis()) ::
+            "end" -> JsNumber(boundary.getEnd().getMillis()) ::
             Nil
-            ) :: Nil
+          ) :: Nil
         )
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval
+        val results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
@@ -123,14 +123,14 @@ class ProgressiveSolver(val dataManager: ActorRef,
         }
 
         val timeInterval = JsObject(
-            "timeInterval" -> JsObject(
-                "start" -> JsNumber(curInterval.getStart().getMillis()) ::
-                "end" -> JsNumber(boundary.getEnd().getMillis()) ::
-                Nil
-            ) :: Nil
+          "timeInterval" -> JsObject(
+            "start" -> JsNumber(curInterval.getStart().getMillis()) ::
+            "end" -> JsNumber(boundary.getEnd().getMillis()) ::
+            Nil
+          ) :: Nil
         )
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval
+        val results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ timeInterval
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -108,8 +108,8 @@ class ProgressiveSolver(val dataManager: ActorRef,
         )
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
-        val infoObject = infoValue.asOpt[JsObject]
-        val results = Json.toJson(infoObject ++ timeInterval.asOpt[JsObject])
+        val infoObject = infoValue.asOpt[JsObject].getOrElse(JsObject(Seq.empty))
+        val results = Json.toJson(infoObject ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
@@ -133,8 +133,8 @@ class ProgressiveSolver(val dataManager: ActorRef,
         )
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
-        val infoObject = infoValue.asOpt[JsObject]
-        val results = Json.toJson(infoObject ++ timeInterval.asOpt[JsObject])
+        val infoObject = infoValue.asOpt[JsObject].getOrElse(JsObject(Seq.empty))
+        val results = Json.toJson(infoObject ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -108,7 +108,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
         )
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
-        val infoObject = infoValue.as[JsObject]
+        val infoObject = infoValue.asOpt[JsObject]
         val results = Json.toJson(infoObject ++ timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
@@ -133,7 +133,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
         )
         // for query with slicing request, add current timeInterval information in its query results.
         val infoValue = queryGroup.postTransform.transform(JsArray(mergedResults))
-        val infoObject = infoValue.as[JsObject]
+        val infoObject = infoValue.asOpt[JsObject]
         val results = Json.toJson(timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -104,8 +104,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
             "end" -> JsNumber(boundary.getEnd().getMillis())
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval)
-log.debug(s"Jul31 1:35pm results ${results}")
+        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ ("timeInterval", timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
@@ -125,8 +124,7 @@ log.debug(s"Jul31 1:35pm results ${results}")
             "end" -> JsNumber(boundary.getEnd().getMillis())
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval)
-log.debug(s"Jul31 1:35pm results ${results}")
+        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] ++ ("timeInterval", timeInterval)
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -104,9 +104,10 @@ class ProgressiveSolver(val dataManager: ActorRef,
             "end" -> JsNumber(boundary.getEnd().getMillis())
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval)
+        var results = Json.toJson(Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval))
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, results)
+
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
 
         queryGroup.queries.foreach(qinfo => suggestViews(qinfo.query))
@@ -124,7 +125,7 @@ class ProgressiveSolver(val dataManager: ActorRef,
             "end" -> JsNumber(boundary.getEnd().getMillis())
         ))
         // for query with slicing request, add current timeInterval information in its query results.
-        var results = Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval)
+        var results = Json.toJson(Json.toJson(queryGroup.postTransform.transform(JsArray(mergedResults))).as[JsObject] + ("timeInterval", timeInterval))
 
         reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, results)
         issueQueryGroup(nextInterval, queryGroup)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/ProgressiveSolver.scala
@@ -11,7 +11,7 @@ import edu.uci.ics.cloudberry.zion.model.impl.{DataSetInfo, QueryPlanner}
 import edu.uci.ics.cloudberry.zion.model.schema._
 import edu.uci.ics.cloudberry.zion.model.slicing.Drum
 import org.joda.time.DateTime
-import play.api.libs.json.{JsArray, JsNumber}
+import play.api.libs.json.{JsArray, JsNumber, JsValue, JsObject, Json}
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
@@ -98,7 +98,18 @@ class ProgressiveSolver(val dataManager: ActorRef,
 
         val limitResultOpt = resultSizeLimitOpt.map(limit => Seq(JsArray(mergedResults.head.value.take(limit))))
         val returnedResult = limitResultOpt.getOrElse(mergedResults)
-        reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, queryGroup.postTransform.transform(JsArray(returnedResult)))
+
+        val timeInterval: JsValue = JsObject(Seq(
+            "timeInterval" -> JsObject(Seq(
+                "min" -> JsNumber(curInterval.getStart().getMillis()),
+                "max" -> JsNumber(boundary.getEnd().getMillis())
+            ))
+        ))
+        // for query with slicing request, add current timeInterval information in its query results.
+        var results = Seq(queryGroup.postTransform.transform(JsArray(mergedResults)), timeInterval)
+        var jsonResults = results.foldLeft(Json.obj())((obj, a) => obj.deepMerge(a.as[JsObject]))
+
+        reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, 1.0, jsonResults)
         reporter ! Reporter.Fin(queryGroup.postTransform.transform(BerryClient.Done))
 
         queryGroup.queries.foreach(qinfo => suggestViews(qinfo.query))
@@ -110,7 +121,18 @@ class ProgressiveSolver(val dataManager: ActorRef,
         } else {
           curInterval.withEnd(boundary.getEnd).toDurationMillis.toDouble / boundary.toDurationMillis
         }
-        reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, queryGroup.postTransform.transform(JsArray(mergedResults)))
+
+        val timeInterval: JsValue = JsObject(Seq(
+            "timeInterval" -> JsObject(Seq(
+                "min" -> JsNumber(curInterval.getStart().getMillis()),
+                "max" -> JsNumber(boundary.getEnd().getMillis())
+            ))
+        ))
+        // for query with slicing request, add current timeInterval information in its query results.
+        var results = Seq(queryGroup.postTransform.transform(JsArray(mergedResults)), timeInterval)
+        var jsonResults = results.foldLeft(Json.obj())((obj, a) => obj.deepMerge(a.as[JsObject]))
+
+        reporter ! Reporter.PartialResult(curInterval.getStartMillis, boundary.getEndMillis, progress, jsonResults)
         issueQueryGroup(nextInterval, queryGroup)
         context.become(askSlice(resultSizeLimitOpt, paceMS, nextLimit, nextInterval, estimator, nextEstimateMS, boundary, queryGroup, mergedResults, DateTime.now), discardOld = true)
       }

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -195,13 +195,14 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       dataManager.reply(getRet(1))
-      sender.expectMsg(Json.toJson(JsObject(
-        "value" -> JsArray(Seq(getRet(1))) ::
-        "timeInterval" -> JsObject(
-          "start" -> JsNumber(interval1.getStart.getMillis()) ::
-          "end" -> JsNumber(endTime.getMillis()) ::
-          Nil) ::
-        Nil)))
+      val result1 : JsValue = JsObject(Seq(
+        "value" -> JsArray(Seq(getRet(1))),
+        "timeInterval" -> JsObject(Seq(
+          "start" -> JsNumber(interval1.getStart.getMillis()),
+          "end" -> JsNumber(endTime.getMillis())
+        ))
+      ))
+      sender.expectMsg(result1)
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))
@@ -212,13 +213,14 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval2.getStartMillis must be_>=(startTime.getMillis)
 
       dataManager.reply(getRet(2))
-      sender.expectMsg(Json.toJson(JsObject(
-        "value" -> JsArray(Seq(getRet(1) ++ getRet(2))) ::
-        "timeInterval" -> JsObject(
-          "start" -> JsNumber(interval2.getStart.getMillis()) ::
-          "end" -> JsNumber(endTime.getMillis()) ::
-          Nil) ::
-        Nil)))
+      val result2 : JsValue = JsObject(Seq(
+        "value" -> JsArray(Seq(getRet(1) ++ getRet(2))),
+        "timeInterval" -> JsObject(Seq(
+          "start" -> JsNumber(interval2.getStart.getMillis()),
+          "end" -> JsNumber(endTime.getMillis())
+        ))
+      ))
+      sender.expectMsg(result2)
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))
@@ -229,13 +231,14 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval3.getStartMillis must be_>=(startTime.getMillis)
 
       dataManager.reply(getRet(3))
-      sender.expectMsg(Json.toJson(JsObject(
-        "value" -> JsArray(Seq(getRet(1) ++ getRet(2) ++ getRet(3))) ::
-        "timeInterval" -> JsObject(
-          "start" -> JsNumber(interval3.getStart.getMillis()) ::
-          "end" -> JsNumber(endTime.getMillis()) ::
-          Nil) ::
-        Nil)))
+      val result3 : JsValue = JsObject(Seq(
+        "value" -> JsArray(Seq(getRet(1) ++ getRet(2) ++ getRet(3))),
+        "timeInterval" -> JsObject(Seq(
+          "start" -> JsNumber(interval3.getStart.getMillis()),
+          "end" -> JsNumber(endTime.getMillis())
+        ))
+      ))
+      sender.expectMsg(result3)
 
       ok
     }
@@ -290,13 +293,14 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
           case Some(TimeField("day", _)) => getRet(2)
         }
       )
-      sender.expectMsg(Json.toJson(JsObject(
-        "value" -> JsArray(Seq(getRet(1), getRet(2))) ::
-        "timeInterval" -> JsObject(
-          "start" -> JsNumber(interval2.getStart.getMillis()) ::
-          "end" -> JsNumber(endTime.getMillis()) ::
-          Nil) ::
-        Nil)))
+      val result : JsValue = JsObject(Seq(
+        "value" -> JsArray(Seq(getRet(1), getRet(2))),
+        "timeInterval" -> JsObject(Seq(
+          "start" -> JsNumber(interval2.getStart.getMillis()),
+          "end" -> JsNumber(endTime.getMillis())
+        ))
+      ))
+      sender.expectMsg(result)
 
       ok
     }
@@ -334,19 +338,22 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       var intervalx = new TInterval(DateTime.now(), DateTime.now())
       var response = JsArray()
       var qx: Query = Query("dataset")
+      var resultx : JsValue = JsObject(Seq.empty)
 
       while (intervalx.getStartMillis > startTime.getMillis) {
         qx = dataManager.receiveOne(5 second).asInstanceOf[Query]
         intervalx = qx.getTimeInterval(TimeField("create_at")).get
         dataManager.reply(getRet(0))
         response ++= getRet(0)
-        sender.expectMsg(Json.toJson(JsObject(
-          "value" -> JsArray(Seq(response)) ::
-          "timeInterval" -> JsObject(
-            "start" -> JsNumber(intervalx.getStart.getMillis()) ::
-            "end" -> JsNumber(endTime.getMillis()) ::
-            Nil) ::
-          Nil)))
+
+        resultx = JsObject(Seq(
+          "value" -> JsArray(Seq(response)),
+          "timeInterval" -> JsObject(Seq(
+            "start" -> JsNumber(intervalx.getStart.getMillis()),
+            "end" -> JsNumber(endTime.getMillis())
+          ))
+        ))
+        sender.expectMsg(resultx)
 
         dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
         dataManager.reply(Seq(TestQuery.sourceInfo))
@@ -388,13 +395,15 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       dataManager.reply(getRet(1))
-      sender.expectMsg(Json.toJson(JsObject(
-        "value" -> JsArray(Seq(getRet(1))) ::
-        "timeInterval" -> JsObject(
-          "start" -> JsNumber(interval1.getStart.getMillis()) ::
-          "end" -> JsNumber(interval1.getEnd.getMillis()) ::
-          Nil) ::
-        Nil)))
+
+      val result1 : JsValue = JsObject(Seq(
+        "value" -> JsArray(Seq(getRet(1))),
+        "timeInterval" -> JsObject(Seq(
+          "start" -> JsNumber(interval1.getStart.getMillis()),
+          "end" -> JsNumber(interval1.getEnd.getMillis())
+        ))
+      ))
+      sender.expectMsg(result1)
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))
@@ -421,13 +430,14 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval11.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       dataManager.reply(getRet(1))
-      sender.expectMsg(Json.toJson(JsObject(
-        "value" -> JsArray(Seq(getRet(1))) ::
-        "timeInterval" -> JsObject(
-          "start" -> JsNumber(interval11.getStart.getMillis()) ::
-          "end" -> JsNumber(interval11.getEnd.getMillis()) ::
-          Nil) ::
-        Nil)))
+      val result11 : JsValue = JsObject(Seq(
+        "value" -> JsArray(Seq(getRet(1))),
+        "timeInterval" -> JsObject(Seq(
+          "start" -> JsNumber(interval11.getStart.getMillis()),
+          "end" -> JsNumber(interval11.getEnd.getMillis())
+        ))
+      ))
+      sender.expectMsg(result11)
 
       ok
     }
@@ -470,13 +480,14 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       dataManager.reply(getRet(1))
-      sender.expectMsg(Json.toJson(JsObject(
-        "value" -> JsArray(Seq(getRet(1))) ::
-        "timeInterval" -> JsObject(
-          "start" -> JsNumber(interval1.getStart.getMillis()) ::
-          "end" -> JsNumber(endTime.getMillis()) ::
-          Nil) ::
-        Nil)))
+      val result1 : JsValue = JsObject(Seq(
+        "value" -> JsArray(Seq(getRet(1))),
+        "timeInterval" -> JsObject(Seq(
+          "start" -> JsNumber(interval1.getStart.getMillis()),
+          "end" -> JsNumber(endTime.getMillis())
+        ))
+      ))
+      sender.expectMsg(result1)
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))
@@ -490,13 +501,14 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
         Json.obj("hour" -> 3, "count" -> 3),
         Json.obj("hour" -> 4, "count" -> 4)
       )))
-      sender.expectMsg(Json.toJson(JsObject(
-        "value" -> JsArray(Seq(getRet(1) ++ getRet(2))) ::
-        "timeInterval" -> JsObject(
-          "start" -> JsNumber(interval2.getStart.getMillis()) ::
-          "end" -> JsNumber(endTime.getMillis()) ::
-          Nil) ::
-        Nil)))
+      val result2 : JsValue = JsObject(Seq(
+        "value" -> JsArray(Seq(getRet(1) ++ getRet(2))),
+        "timeInterval" -> JsObject(Seq(
+          "start" -> JsNumber(interval2.getStart.getMillis()),
+          "end" -> JsNumber(endTime.getMillis())
+        ))
+      ))
+      sender.expectMsg(result2)
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -195,8 +195,13 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       dataManager.reply(getRet(1))
-      ///sender.expectMsg(JsArray(Seq(getRet(1))))
-sender.expectMsg(Json.toJson(JsObject("value" -> JsArray(Seq(getRet(1))) :: "timeInterval" -> JsObject("start" -> JsNumber(interval1.getStart.getMillis()) :: "end" -> JsNumber(endTime.getMillis()) :: Nil) :: Nil)))
+      sender.expectMsg(Json.toJson(JsObject(
+        "value" -> JsArray(Seq(getRet(1))) ::
+        "timeInterval" -> JsObject(
+          "start" -> JsNumber(interval1.getStart.getMillis()) ::
+          "end" -> JsNumber(endTime.getMillis()) ::
+          Nil) ::
+        Nil)))
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/ReactiveBerryClientTest.scala
@@ -195,7 +195,8 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       dataManager.reply(getRet(1))
-      sender.expectMsg(JsArray(Seq(getRet(1))))
+      ///sender.expectMsg(JsArray(Seq(getRet(1))))
+sender.expectMsg(Json.toJson(JsObject("value" -> JsArray(Seq(getRet(1))) :: "timeInterval" -> JsObject("start" -> JsNumber(interval1.getStart.getMillis()) :: "end" -> JsNumber(endTime.getMillis()) :: Nil) :: Nil)))
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))
@@ -206,7 +207,13 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval2.getStartMillis must be_>=(startTime.getMillis)
 
       dataManager.reply(getRet(2))
-      sender.expectMsg(JsArray(Seq(getRet(1) ++ getRet(2))))
+      sender.expectMsg(Json.toJson(JsObject(
+        "value" -> JsArray(Seq(getRet(1) ++ getRet(2))) ::
+        "timeInterval" -> JsObject(
+          "start" -> JsNumber(interval2.getStart.getMillis()) ::
+          "end" -> JsNumber(endTime.getMillis()) ::
+          Nil) ::
+        Nil)))
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))
@@ -217,7 +224,14 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval3.getStartMillis must be_>=(startTime.getMillis)
 
       dataManager.reply(getRet(3))
-      sender.expectMsg(JsArray(Seq(getRet(1) ++ getRet(2) ++ getRet(3))))
+      sender.expectMsg(Json.toJson(JsObject(
+        "value" -> JsArray(Seq(getRet(1) ++ getRet(2) ++ getRet(3))) ::
+        "timeInterval" -> JsObject(
+          "start" -> JsNumber(interval3.getStart.getMillis()) ::
+          "end" -> JsNumber(endTime.getMillis()) ::
+          Nil) ::
+        Nil)))
+
       ok
     }
 
@@ -271,7 +285,13 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
           case Some(TimeField("day", _)) => getRet(2)
         }
       )
-      sender.expectMsg(JsArray(Seq(getRet(1), getRet(2))))
+      sender.expectMsg(Json.toJson(JsObject(
+        "value" -> JsArray(Seq(getRet(1), getRet(2))) ::
+        "timeInterval" -> JsObject(
+          "start" -> JsNumber(interval2.getStart.getMillis()) ::
+          "end" -> JsNumber(endTime.getMillis()) ::
+          Nil) ::
+        Nil)))
 
       ok
     }
@@ -315,7 +335,13 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
         intervalx = qx.getTimeInterval(TimeField("create_at")).get
         dataManager.reply(getRet(0))
         response ++= getRet(0)
-        sender.expectMsg(JsArray(Seq(response)))
+        sender.expectMsg(Json.toJson(JsObject(
+          "value" -> JsArray(Seq(response)) ::
+          "timeInterval" -> JsObject(
+            "start" -> JsNumber(intervalx.getStart.getMillis()) ::
+            "end" -> JsNumber(endTime.getMillis()) ::
+            Nil) ::
+          Nil)))
 
         dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
         dataManager.reply(Seq(TestQuery.sourceInfo))
@@ -323,6 +349,7 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       qx.getTimeInterval(TimeField("create_at")).get.getStartMillis must_== startTime.getMillis
 
       dataManager.expectMsg(createView)
+
       ok
     }
     "cancel the haven't finished query if newer query comes" in {
@@ -356,7 +383,13 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       dataManager.reply(getRet(1))
-      sender.expectMsg(JsArray(Seq(getRet(1))))
+      sender.expectMsg(Json.toJson(JsObject(
+        "value" -> JsArray(Seq(getRet(1))) ::
+        "timeInterval" -> JsObject(
+          "start" -> JsNumber(interval1.getStart.getMillis()) ::
+          "end" -> JsNumber(interval1.getEnd.getMillis()) ::
+          Nil) ::
+        Nil)))
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))
@@ -383,7 +416,14 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval11.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       dataManager.reply(getRet(1))
-      sender.expectMsg(JsArray(Seq(getRet(1))))
+      sender.expectMsg(Json.toJson(JsObject(
+        "value" -> JsArray(Seq(getRet(1))) ::
+        "timeInterval" -> JsObject(
+          "start" -> JsNumber(interval11.getStart.getMillis()) ::
+          "end" -> JsNumber(interval11.getEnd.getMillis()) ::
+          Nil) ::
+        Nil)))
+
       ok
     }
     "stop when the number of returning results reached the limit" in {
@@ -425,7 +465,13 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
       interval1.toDurationMillis must_== Config.Default.FirstQueryTimeGap.toMillis
 
       dataManager.reply(getRet(1))
-      sender.expectMsg(JsArray(Seq(getRet(1))))
+      sender.expectMsg(Json.toJson(JsObject(
+        "value" -> JsArray(Seq(getRet(1))) ::
+        "timeInterval" -> JsObject(
+          "start" -> JsNumber(interval1.getStart.getMillis()) ::
+          "end" -> JsNumber(endTime.getMillis()) ::
+          Nil) ::
+        Nil)))
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))
@@ -439,7 +485,13 @@ class ReactiveBerryClientTest extends TestkitExample with SpecificationLike with
         Json.obj("hour" -> 3, "count" -> 3),
         Json.obj("hour" -> 4, "count" -> 4)
       )))
-      sender.expectMsg(JsArray(Seq(getRet(1) ++ getRet(2))))
+      sender.expectMsg(Json.toJson(JsObject(
+        "value" -> JsArray(Seq(getRet(1) ++ getRet(2))) ::
+        "timeInterval" -> JsObject(
+          "start" -> JsNumber(interval2.getStart.getMillis()) ::
+          "end" -> JsNumber(endTime.getMillis()) ::
+          Nil) ::
+        Nil)))
 
       dataManager.receiveOne(5 seconds).asInstanceOf[DataStoreManager.AskInfoAndViews]
       dataManager.reply(Seq(TestQuery.sourceInfo))


### PR DESCRIPTION
Cloudberry carry the slicing `timeInterval` information along with the slicing results.

An example query result for query with `cloudberryConfig.querySliceMills > 0`:
> {
category: "batchWithPartialGeoRequest"
id: "batchWithPartialGeoRequest"
timeInterval: {start: 1493366400000, end: 1493539200000}
value: [Array(0), Array(4), Array(0)]
> }

Otherwise, the result will not include the  `timeInterval` variable:
> {
category: "sample"
id: "sample"
value: [Array(0)]
> }