### PR TITLE
Fix bug of Pinmap retrieving individual tweet query

### DIFF
--- a/examples/twittermap/web/public/javascripts/common/services.js
+++ b/examples/twittermap/web/public/javascripts/common/services.js
@@ -535,7 +535,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache'])
 
           var setpinFilter = [{
               field: "id",
-              relation: "in",
+              relation: "=",
               values: pinid
           }];
 


### PR DESCRIPTION
Current pinmap retrieving individual tweet query is using relation `in`, which will generate AsterixDB query as following:
```
select t.`user`.`id` as `user.id`,t.`text` as `text`,t.`id` as `id`,t.`create_at` as `create_at`,t.`user`.`profile_image_url` as `user.profile_image_url`,t.`user`.`name` as `user.name`
from twitter.ds_tweet t
where t.`id` in [943220481355689984]
order by t.`create_at` desc
limit 10
offset 0;
```
AsterixDB will take too long time to compute this query, so the symptom is that AsterixDB will not return any result at all.

To fix this bug, we modify the pinmap retrieving individual tweet query by using relation `=`, which will generate AsterixDB query as following:
```
select t.`user`.`id` as `user.id`,t.`text` as `text`,t.`id` as `id`,t.`create_at` as `create_at`,t.`user`.`profile_image_url` as `user.profile_image_url`,t.`user`.`name` as `user.name`
from twitter.ds_tweet t
where t.`id` = 943220481355689984
order by t.`create_at` desc
limit 10
offset 0;
```
And AsterixDB will return result for this query very fast, tested on 1.2 Billion records dataset.
