### PR TITLE
[issue #582] Fix some frontend issues

### DIFF
--- a/examples/twittermap/web/app/views/twittermap/index.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/index.scala.html
@@ -51,11 +51,6 @@
         <li role="presentation" ng-click="click = 1; showTab('sampletweetTab')" class="active"><a href="#tweet" data-toggle="tab"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a></li>
         <li role="presentation" ng-click="click = 1; showTab('aboutTab')"><a href="#about" data-toggle="tab"><i class="fa fa-info-circle fa-2x"></i></a></li>
         <li><br/></li>
-        <mapchoose>
-          <li role="presentation"><img id="img1" name="img1" title="Count Map" src="/assets/images/aggregation_map.png" width="63" height="63" ></li><br/>
-          <li role="presentation"><img id="img2" name="img2" title="Heat Map" src="/assets/images/heat_map_no_border.png" width="63" height="63" ></li><br/>
-          <li role="presentation"><img id="img3" name="img3" title="Pin Map" src="/assets/images/point_map_no_border.png" width="63" height="63"></li>
-        </mapchoose>
       </ul>
     </div>
     <div class="col-xs-10">
@@ -85,6 +80,14 @@
       </div>
     </div>
   </div>
+
+  <mapchoose>
+    <ul>
+      <li role="presentation"><img id="img1" name="img1" title="Count Map" src="/assets/images/aggregation_map.png" width="45" height="45" ><li/>
+      <li role="presentation"><img id="img2" name="img2" title="Heat Map" src="/assets/images/heat_map_no_border.png" width="45" height="45" ></li>
+      <li role="presentation"><img id="img3" name="img3" title="Pin Map" src="/assets/images/point_map_no_border.png" width="45" height="45"></li>
+    </ul>
+  </mapchoose>
 
   <div class = "exception-bar">
     <exception-bar></exception-bar>

--- a/examples/twittermap/web/app/views/twittermap/index.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/index.scala.html
@@ -48,8 +48,8 @@
       <a href="javascript:void(0)" class="closebtn" onclick="closeRightMenu()">&times;</a>
       <ul class="nav nav-tabs tabs-left">
         <li role="presentation" ng-click="click = 1; showTab('hashtagTab')"><a href="#hashtag" data-toggle="tab"><i class="fa fa-hashtag fa-2x" aria-hidden="true"></i></a></li>
-        <li role="presentation" ng-click="click = 1; showTab('sampletweetTab')"><a href="#tweet" data-toggle="tab"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a></li>
-        <li role="presentation" ng-click="click = 1; showTab('aboutTab')" class="active"><a href="#about" data-toggle="tab"><i class="fa fa-info-circle fa-2x"></i></a></li>
+        <li role="presentation" ng-click="click = 1; showTab('sampletweetTab')" class="active"><a href="#tweet" data-toggle="tab"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a></li>
+        <li role="presentation" ng-click="click = 1; showTab('aboutTab')"><a href="#about" data-toggle="tab"><i class="fa fa-info-circle fa-2x"></i></a></li>
         <li><br/></li>
         <mapchoose>
           <li role="presentation"><img id="img1" name="img1" title="Count Map" src="/assets/images/aggregation_map.png" width="63" height="63" ></li><br/>
@@ -61,8 +61,8 @@
     <div class="col-xs-10">
       <div class="tab-content">
         <hashtag id="hashtag" class="tab-pane"></hashtag>
-        <tweet id="tweet" class="tab-pane"></tweet>
-        <div id="about" class="tab-pane active">
+        <tweet id="tweet" class="tab-pane active"></tweet>
+        <div id="about" class="tab-pane">
           <h1> About </h1>
           <p><b>TwitterMap</b> is a research prototype powered by <a href="http://cloudberry.ics.uci.edu/">Cloudberry</a>
             and <a href="https://asterixdb.apache.org/">Apache AsterixDB</a> to support

--- a/examples/twittermap/web/app/views/twittermap/index.scala.html
+++ b/examples/twittermap/web/app/views/twittermap/index.scala.html
@@ -83,7 +83,7 @@
 
   <mapchoose>
     <ul>
-      <li role="presentation"><img id="img1" name="img1" title="Count Map" src="/assets/images/aggregation_map.png" width="45" height="45" ><li/>
+      <li role="presentation"><img id="img1" name="img1" title="Count Map" src="/assets/images/aggregation_map.png" width="45" height="45" ></li>
       <li role="presentation"><img id="img2" name="img2" title="Heat Map" src="/assets/images/heat_map_no_border.png" width="45" height="45" ></li>
       <li role="presentation"><img id="img3" name="img3" title="Pin Map" src="/assets/images/point_map_no_border.png" width="45" height="45"></li>
     </ul>

--- a/examples/twittermap/web/public/javascripts/sidebar/controllers.js
+++ b/examples/twittermap/web/public/javascripts/sidebar/controllers.js
@@ -7,9 +7,9 @@ angular.module("cloudberry.sidebar", ["cloudberry.common"])
 
     // Flag whether sidebar tab is open
     $scope.isHashTagOpen = false;
-    $scope.isSampleTweetsOpen = false;
+    $scope.isSampleTweetsOpen = true;
 
-    $scope.currentTab = "aboutTab";
+    $scope.currentTab = "sampletweetTab";
 
     function sendHashTagQuery() {
       var hashtagRequest = queryUtil.getHashTagRequest(cloudberry.parameters);

--- a/examples/twittermap/web/public/stylesheets/main.css
+++ b/examples/twittermap/web/public/stylesheets/main.css
@@ -131,8 +131,8 @@ search-bar {
 #powerby{
   position: absolute;
   bottom: 0%;
-  right: 0;
-  width: 10%;
+  right: 1%;
+  /*width: 10%;*/
   z-index: 0;
 }
 

--- a/examples/twittermap/web/public/stylesheets/main.css
+++ b/examples/twittermap/web/public/stylesheets/main.css
@@ -194,6 +194,8 @@ time-series {
 
 .search-keyword-btn-group{
   margin-left: 36%;
+  position: relative;
+  overflow: hidden;
 }
 /*For the popup box of tweets in points map*/
 .tweet {
@@ -277,3 +279,8 @@ mapchoose li {
   border: 0.5px solid black;
 }
 
+.input-group {
+  position: relative; 
+  overflow: hidden;
+  width: 100%;
+}

--- a/examples/twittermap/web/public/stylesheets/main.css
+++ b/examples/twittermap/web/public/stylesheets/main.css
@@ -21,7 +21,7 @@ body {
   top: 0;
   bottom: 0;
   width: 24%;
-  height: 700px;
+  height: 630px;
   overflow: auto;
   margin-left: 0%;
   -webkit-transition: all 0.5s ease;
@@ -125,13 +125,13 @@ search-bar {
 
 .btn.btn-info{
   position: relative;
-  left: 110%;
+  /*left: 110%;*/
 }
 
 #powerby{
   position: absolute;
   bottom: 0%;
-  left: 74%;
+  right: 0;
   width: 10%;
   z-index: 0;
 }
@@ -257,5 +257,23 @@ time-series {
   margin-left: 5px;
 }
 
+mapchoose {
+  position: absolute;
+  left: 80%;
+  bottom: 0;
+  background-color: white;
+  opacity: 0.8;
+}
 
+mapchoose ul {
+  list-style-type: none;
+  margin: 0px; 
+  padding: 0px;
+}
+
+mapchoose li {
+  float: left;
+  display: inline;
+  border: 0.5px solid black;
+}
 

--- a/examples/twittermap/web/public/stylesheets/main.css
+++ b/examples/twittermap/web/public/stylesheets/main.css
@@ -279,6 +279,7 @@ mapchoose {
   bottom: 0;
   background-color: white;
   opacity: 0.8;
+  border-radius: 10px;
 }
 
 mapchoose ul {
@@ -290,7 +291,10 @@ mapchoose ul {
 mapchoose li {
   float: left;
   display: inline;
-  border: 0.5px solid black;
+}
+
+mapchoose li #img1, #img2 {
+  border-right: 0.5px solid black;
 }
 
 .input-group {

--- a/examples/twittermap/web/public/stylesheets/main.css
+++ b/examples/twittermap/web/public/stylesheets/main.css
@@ -30,7 +30,7 @@ body {
   transition: all 0.5s ease;
   background-color: white;
   opacity: 1.0;
-  z-index: 1;
+  z-index: 1000;
 }
 
 #img1, #img2, #img3 {
@@ -149,7 +149,7 @@ search-bar {
 }
 
 time-series {
-  z-index: 1000;
+  z-index: 1;
   pointer-events: auto;
   position: relative;
   display: inline-block;


### PR DESCRIPTION
Overview
----
- [x] When you click the hamburger button, the twitter part will be shown first.
- [x] Make the time bar go behind to the sidebar.
- [x] Put small map image icon outside of sidebar.
- [x] Make the search bar looks more natural.

Result
-------
When you first click the hamburger button to open sidebar, the twitter tab is shown first.
<img width="1440" alt="screen shot 2018-08-21 at 2 18 34 pm" src="https://user-images.githubusercontent.com/23238126/44429712-3da3a600-a54d-11e8-8d77-2d2c1264aa54.png">
 
The time bar goes behind the sidebar.
<img width="924" alt="screen shot 2018-08-21 at 2 49 29 pm" src="https://user-images.githubusercontent.com/23238126/44431059-8bbaa880-a551-11e8-8a7b-c51d0d729e3f.png">

The map icon images go outside of the sidebar.
<img width="1440" alt="screen shot 2018-09-18 at 10 30 30 am" src="https://user-images.githubusercontent.com/23238126/45705677-1087ea80-bb2f-11e8-9868-26cde3e118c4.png">


Made the search bar more smoothly.
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/23238126/45651739-32c62d80-ba87-11e8-9a70-99cfe96caa69.gif)
