### PR TITLE
[issue #563] Cloudberry does not change datatype "bag" to "string" after unnest it

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryResolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryResolver.scala
@@ -84,18 +84,7 @@ object QueryResolver {
     val producedFields = mutable.Map.newBuilder[String, Field]
     val resolved = unnests.map { unnest =>
       val field = resolveField(unnest.field, fieldMap)
-      var asField : Field = null
-
-      val bagField = field.asInstanceOf[BagField]
-      bagField.innerType match {
-        case DataType.Number => asField = NumberField(unnest.as, field.isOptional)
-        case DataType.Time => asField = TimeField(unnest.as, field.isOptional)
-        case DataType.String => asField = StringField(unnest.as, field.isOptional)
-        case DataType.Text => asField = TextField(unnest.as, field.isOptional)
-        case DataType.Point => asField = PointField(unnest.as, field.isOptional)
-        case DataType.Boolean => asField = PointField(unnest.as, field.isOptional)
-      }
-
+      val asField = Field.asInnerType(field, unnest.as)
       producedFields += unnest.as -> asField
       UnnestStatement(field, asField)
     }

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryResolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryResolver.scala
@@ -84,7 +84,18 @@ object QueryResolver {
     val producedFields = mutable.Map.newBuilder[String, Field]
     val resolved = unnests.map { unnest =>
       val field = resolveField(unnest.field, fieldMap)
-      val asField = Field.as(field, unnest.as)
+      var asField : Field = null
+
+      val bagField = field.asInstanceOf[BagField]
+      bagField.innerType match {
+        case DataType.Number => asField = NumberField(unnest.as, field.isOptional)
+        case DataType.Time => asField = TimeField(unnest.as, field.isOptional)
+        case DataType.String => asField = StringField(unnest.as, field.isOptional)
+        case DataType.Text => asField = TextField(unnest.as, field.isOptional)
+        case DataType.Point => asField = PointField(unnest.as, field.isOptional)
+        case DataType.Boolean => asField = PointField(unnest.as, field.isOptional)
+      }
+
       producedFields += unnest.as -> asField
       UnnestStatement(field, asField)
     }

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
@@ -89,6 +89,24 @@ object Field {
 
   }
 
+  /**
+    * Copy a given field "innerType" with a new name, used in resolveUnnests
+    * @param field
+    * @param name
+    * @return
+    */
+  def asInnerType(field: Field, name: String): Field = {
+    val bagField = field.asInstanceOf[BagField]
+    bagField.innerType match {
+      case DataType.Number => NumberField(name, field.isOptional)
+      case DataType.Time => TimeField(name, field.isOptional)
+      case DataType.String => StringField(name, field.isOptional)
+      case DataType.Text => TextField(name, field.isOptional)
+      case DataType.Point => PointField(name, field.isOptional)
+      case DataType.Boolean => PointField(name, field.isOptional)
+    }
+  }
+
 }
 
 case class NumberField(override val name: String, override val isOptional: Boolean = false) extends Field {

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
@@ -84,14 +84,7 @@ object Field {
         RecordField(name, recordField.schema, recordField.isOptional)
       case DataType.Bag =>
         val bagField = field.asInstanceOf[BagField]
-        bagField.innerType match {
-          case DataType.Number => NumberField(name, field.isOptional)
-          case DataType.Time => TimeField(name, field.isOptional)
-          case DataType.String => StringField(name, field.isOptional)
-          case DataType.Text => TextField(name, field.isOptional)
-          case DataType.Point => PointField(name, field.isOptional)
-          case DataType.Boolean => PointField(name, field.isOptional)
-        }
+        BagField(name, bagField.innerType, bagField.isOptional)
     }
 
   }

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
@@ -103,7 +103,7 @@ object Field {
       case DataType.String => StringField(name, field.isOptional)
       case DataType.Text => TextField(name, field.isOptional)
       case DataType.Point => PointField(name, field.isOptional)
-      case DataType.Boolean => PointField(name, field.isOptional)
+      case DataType.Boolean => BooleanField(name, field.isOptional)
     }
   }
 

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
@@ -84,7 +84,14 @@ object Field {
         RecordField(name, recordField.schema, recordField.isOptional)
       case DataType.Bag =>
         val bagField = field.asInstanceOf[BagField]
-        BagField(name, bagField.innerType, bagField.isOptional)
+        bagField.innerType match {
+          case DataType.Number => NumberField(name, field.isOptional)
+          case DataType.Time => TimeField(name, field.isOptional)
+          case DataType.String => StringField(name, field.isOptional)
+          case DataType.Text => TextField(name, field.isOptional)
+          case DataType.Point => PointField(name, field.isOptional)
+          case DataType.Boolean => PointField(name, field.isOptional)
+        }
     }
 
   }

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestQuery.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestQuery.scala
@@ -25,7 +25,7 @@ object TestQuery {
   val text = twitterField("text")
   val lang = twitterField("lang")
 
-  val tag = Field.as(hashtags, "tag")
+  val tag = Field.asInnerType(hashtags, "tag")
   val hash = Field.as(hashtags, "hashtags")
   val geoStateID = twitterField("geo_tag.stateID")
   val isRetweet = twitterField("is_retweet")


### PR DESCRIPTION



## Overview

Please refer to issue #563.
It is aimed to modify cloudberry, so that it can support filter of string datatype after **unnest** operation is applied to **bag** datatype. 

- **In the current Cloudberry, the datatype of "bag" does not change after unnest it. We should change the datatype to its innerType, eg. "string", after unnest the "bag" datatype.**


## Result

1. The json send to cloudberry is
![image](https://user-images.githubusercontent.com/26839941/43605801-71e9c240-964e-11e8-9b38-a5a52634510f.png)

2. The query sent to AsterixDB by cloudberry is ```select `month` as `month`,coll_count(g) as `count`
from twitter.ds_tweet_b5c0b187fe309af0f4d35982fd961d7e t
unnest t.`hashtags` `unnest0`
where not(is_null(t.`hashtags`)) and t.`create_at` >= datetime('2017-01-24T08:00:00.000Z') and t.`create_at` < datetime('2018-01-04T08:00:00.000Z') and t.`geo_tag`.`stateID` in [ 37,51,24,11,10,34,42,9,44,48,35,4,40,6,20,32,8,49,12,22,28,1,13,45,5,47,21,29,54,17,18,39,19,55,26,27,31,56,41,46,16,30,53,38,25,36,50,33,23,2 ] and `unnest0`="love"
group by get_interval_start_datetime(interval_bin(t.`create_at`, datetime('1990-01-01T00:00:00.000Z'),  year_month_duration("P1M") )) as `month` group as g;```

3. The query result is
![image](https://user-images.githubusercontent.com/26839941/43605858-9873a4c6-964e-11e8-9494-a64e23eca4ec.png)



