### PR TITLE
Fix the bug about assign BooleanField

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
@@ -75,7 +75,7 @@ object Field {
       case DataType.String => StringField(name, field.isOptional)
       case DataType.Text => TextField(name, field.isOptional)
       case DataType.Point => PointField(name, field.isOptional)
-      case DataType.Boolean => PointField(name, field.isOptional)
+      case DataType.Boolean => BooleanField(name, field.isOptional)
       case DataType.Hierarchy =>
         val hierarchyField = field.asInstanceOf[HierarchyField]
         HierarchyField(name, hierarchyField.innerType, hierarchyField.levels, hierarchyField.isOptional)


### PR DESCRIPTION
The bug is in `cloudberry/zion/model/schema/AbstractSchema.scala` line 78.

![image](https://user-images.githubusercontent.com/26839941/44878336-77666200-ac5b-11e8-8f66-052be98cd23a.png)

It should be **"case DataType.Boolean => BooleanField(name, field.isOptional)"**
