### PR TITLE
Fix the bug of counting the total number of tweets in the dataset

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/OriginalDataAgent.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/OriginalDataAgent.scala
@@ -69,9 +69,10 @@ class OriginalDataAgent(val dataSetInfo: DataSetInfo,
     }
     val temporalSchema = dataSetInfo.schema.asInstanceOf[Schema]
     val now = DateTime.now().minusMillis(1)
-    val filter = FilterStatement(temporalSchema.timeField, None, Relation.inRange, Seq(start, now).map(TimeField.TimeFormat.print))
+    val startFilter = FilterStatement(temporalSchema.timeField, None, Relation.>, Seq(start).map(TimeField.TimeFormat.print))
+    val endFilter = FilterStatement(temporalSchema.timeField, None, Relation.<=, Seq(now).map(TimeField.TimeFormat.print))
     val aggr = GlobalAggregateStatement(AggregateStatement(temporalSchema.fieldMap("*"), Count, Field.as(Count(temporalSchema.fieldMap("*")), "count")))
-    val queryCardinality = Query(dbName, filter = Seq(filter), globalAggr = Some(aggr))
+    val queryCardinality = Query(dbName, filter = Seq(startFilter, endFilter), globalAggr = Some(aggr))
     conn.postQuery(queryParser.generate(queryCardinality, Map(dbName -> temporalSchema)))
       .map(r => Cardinality(start, now, (r \\ "count").head.as[Long])) pipeTo self
   }


### PR DESCRIPTION
### Example
* Dataset: 47,000 tweets (from 01/01/2016 to 05/05/2017)

### Bug
* When cloudberry first starts, cloudberry sends a request to count the number of tweets in the dataset. Cloudberry will get the response: ```[{"count": 47000}]```. Then, for some reason, cloudberry is out of connection. After user refreshes the web page, cloudberry sends another query to count the number of tweets created from 05/05/2017 (inclusive) to current time (exclusive). After getting the result (E.g. ```[{"count": 2}]```), cloudberry adds the two number together and upserts ```47002``` into berry.meta. In fact, in the second query, cloudberry should not count the number of tweets created on 05/05/2017, because this number is included in the first response: ```[{"count": 47000}]```.

### Solution
* In the second query, Cloudberry will only count the number of tweets created from 05/05/2017 (exclusive) to current time (inclusive). In this case, whenever Cloudberry collects the statistics afterwards, the result should be correct.

### Code implementation: 
* Delete the existing wrong ```FilterStatement```
* Add a ```FilterStatement``` with ```Relation.>``` to exclude the start date.
* Add a ```FilterStatement``` with ```Relation.<=``` to include the end date.
* Add the two new ```FilterStatement``` into the query.
