### PR TITLE
Revert "Fix date format timezone bug in AbstractSchema"

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/schema/AbstractSchema.scala
@@ -121,7 +121,7 @@ case class TimeField(override val name: String, override val isOptional: Boolean
 }
 
 object TimeField {
-  val TimeFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+  val TimeFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   val TimeFormatForSQL = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS")
 }
 

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestDataSetInfo.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/TestDataSetInfo.scala
@@ -10,8 +10,8 @@ object TestDataSetInfo {
   DateTimeZone.setDefault(DateTimeZone.UTC)
   val starDateTime = new DateTime(2004, 12, 25, 0, 0, 0, 0)
   val endDateTime = new DateTime(2016, 1, 1, 0, 0, 0, 0)
-  val endTimeString = "2016-01-01T00:00:00.000+0000"
-  val startTimeString = "2004-12-25T00:00:00.000+0000"
+  val endTimeString = "2016-01-01T00:00:00.000Z"
+  val startTimeString = "2004-12-25T00:00:00.000Z"
 
   val interval = new Interval(starDateTime, endDateTime)
   val globalAggr = GlobalAggregateStatement(aggrCount)
@@ -227,11 +227,11 @@ object TestDataSetInfo {
        |      {"name":"retweet_count","isOptional":false,"datatype":"Number"},
        |      {"name":"user.status_count","isOptional":false,"datatype":"Number"}],
        |   "primaryKey":["id"],"timeField":"create_at"},
-       |"dataInterval":{"start":"2015-01-01T00:00:00.000+0000",
-       |                "end":"2017-01-01T00:00:00.000+0000"},
-       |"stats":{"createTime":"2015-01-01T00:00:00.000+0000",
-       |         "lastModifyTime":"2017-01-01T00:00:00.000+0000",
-       |         "lastReadTime":"2017-01-01T00:00:00.000+0000",
+       |"dataInterval":{"start":"2015-01-01T00:00:00.000Z",
+       |                "end":"2017-01-01T00:00:00.000Z"},
+       |"stats":{"createTime":"2015-01-01T00:00:00.000Z",
+       |         "lastModifyTime":"2017-01-01T00:00:00.000Z",
+       |         "lastReadTime":"2017-01-01T00:00:00.000Z",
        |         "cardinality":10000
        |         }
        |}
@@ -267,11 +267,11 @@ object TestDataSetInfo {
        |      {"name":"retweet_count","isOptional":false,"datatype":"Number"},
        |      {"name":"user.status_count","isOptional":false,"datatype":"Number"}],
        |   "primaryKey":["id"],"timeField":"create_at"},
-       |"dataInterval":{"start":"2015-01-01T00:00:00.000+0000",
-       |                "end":"2016-06-01T00:00:00.000+0000"},
-       |"stats":{"createTime":"2015-01-01T00:00:00.000+0000",
-       |         "lastModifyTime":"2016-06-01T00:00:00.000+0000",
-       |         "lastReadTime":"2016-06-01T00:00:00.000+0000",
+       |"dataInterval":{"start":"2015-01-01T00:00:00.000Z",
+       |                "end":"2016-06-01T00:00:00.000Z"},
+       |"stats":{"createTime":"2015-01-01T00:00:00.000Z",
+       |         "lastModifyTime":"2016-06-01T00:00:00.000Z",
+       |         "lastReadTime":"2016-06-01T00:00:00.000Z",
        |         "cardinality":50
        |         }
        |}


### PR DESCRIPTION
Reverts ISG-ICS/cloudberry#632

# Overview
Since current ingestion script does not add timezone info to the `adm` instance pushed to AsterixDB, the tweets in current production DB is all hardcoded by `UTC` timezone, which should be `PST` timezone instead. And this problem causes current DB will not work properly with this fix merged.
Therefore, this PR could be merged once the problem stated above is solved.