### PR TITLE
[Backup] Fix bug of geotagging module generating adm without timezone

### DIFF
--- a/examples/twittermap/noah/src/main/scala/edu/uci/ics/cloudberry/noah/adm/ADM.java
+++ b/examples/twittermap/noah/src/main/scala/edu/uci/ics/cloudberry/noah/adm/ADM.java
@@ -14,6 +14,7 @@ import java.util.Date;
 public class ADM {
 
     public static final SimpleDateFormat ADMDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    // ADM Time formatter needs to contain the timezone information to make AsterixDB consistent with Cloudberry
     public static final SimpleDateFormat ADMTimeFormat = new SimpleDateFormat("HH:mm:ss.SSSZZZZ");
 
     public static String mkADMConstructor(String constructor, String content) {

--- a/examples/twittermap/noah/src/main/scala/edu/uci/ics/cloudberry/noah/adm/ADM.java
+++ b/examples/twittermap/noah/src/main/scala/edu/uci/ics/cloudberry/noah/adm/ADM.java
@@ -14,7 +14,7 @@ import java.util.Date;
 public class ADM {
 
     public static final SimpleDateFormat ADMDateFormat = new SimpleDateFormat("yyyy-MM-dd");
-    public static final SimpleDateFormat ADMTimeFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+    public static final SimpleDateFormat ADMTimeFormat = new SimpleDateFormat("HH:mm:ss.SSSZZZZ");
 
     public static String mkADMConstructor(String constructor, String content) {
         return constructor + "(\"" + content + "\")";


### PR DESCRIPTION
# Overview
In `noah/adm/ADM.java`, when geotagging module generates ADM instance for ingestion, the datetime format does NOT include `timezone` information, and AsterixDB will treat it as UTC timezone by default, so that all tweets ingested into AsterixDB becomes 8 hours behind its real timestamp (PST).