### PR TITLE
[Fix] Fix maven dependency url of ojdbc

### DIFF
--- a/cloudberry/project/dependencies.scala
+++ b/cloudberry/project/dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val zionDependencies: Seq[ModuleID] = Seq(
     "joda-time" % "joda-time" % "2.9.3",
     "com.typesafe.akka" %% "akka-actor" % "2.4.4",
-    "com.github.noraui" % "ojdbc8" % "12.2.0.1",
+    "oracle" % "ojdbc6" % "11.2.0.3",
     "oracle" % "sdoapi" % "11.2.0",
     "mysql" % "mysql-connector-java" % "5.1.24",
     "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",


### PR DESCRIPTION
Fix the maven dependency url for ojdbc, previous url has been deprecated.