### PR TITLE
[Script] Only alert when the total count is not changed during the last one hour

### DIFF
--- a/examples/twittermap/script/berryGuard.sh
+++ b/examples/twittermap/script/berryGuard.sh
@@ -88,12 +88,12 @@ touchCloudberry()
 	local cnt=$(echo $result | python -c "import sys, json; print json.load(sys.stdin)['count']")
 	echo "cnt = " ${cnt}
 	echo "pre_cnt = " ${preCnt}
-	if [ "${cnt}" -gt "${preCnt}" ] ; then
+	if [ "${cnt}" -ne "${preCnt}" ] ; then
 		echo "[Good!] Cloudberry is working properly."
 		preCnt=${cnt}
 		return
 	fi
-	if [ "${cnt}" -le "${preCnt}" ] ; then
+	if [ "${cnt}" -eq "${preCnt}" ] ; then
 	    echo "[Bad!] Twitter ingestion may stop or Cloudberry may malfunction."
 	    sendEmail "Twitter ingestion may stop or Cloudberry may malfunction." "Twitter ingestion may stop or Cloudberry may malfunction. The total count of ds_tweet retrieved is ${cnt} this time and ${preCnt} last time."
 	    preCnt=${cnt}


### PR DESCRIPTION
#### Problem
The total count returned from Cloudberry is estimated based on the speed of ingestion, the speed being collected every 4 hours by Cloudberry. During the daytime when more tweets are ingested into DB, the speed is higher than that during the late night. Therefore, it's possible that Cloudberry is overestimating the speed of increasing of total count during the night, and once the every-4-hour synchronization happens during late night, the total count returned from Cloudberry is reduced compared to previous returned result.
#### Solution
`berry-guard` will compare this time total count result returned with last time, but will only alert if the two numbers are equal and will mute if either the number goes up or down.