### PR TITLE
[Backend] Enable RestfulSolver suggesting view

### DIFF
--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTSolver.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/actor/RESTSolver.scala
@@ -28,9 +28,8 @@ class RESTSolver(val dataManager: ActorRef,
         // handle average results
         val avgHandledResult = r.value.map(rows => QueryPlanner.handleAvg(rows.as[JsArray]))
         out ! transform.transform(Json.parse(Json.toJson(avgHandledResult).toString()))
-        //Disabled this suggest views to avoid competing resources in DB with ongoing ProgressiveSolver.
-        //TODO Once we have view management mechanism, could use a common service to request a view creation.
-        //qs.foreach(suggestViews)
+        // suggest view to QueryPlanner
+        qs.foreach(suggestViews)
       }
   }
 

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/SimpleBerryClientTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/actor/SimpleBerryClientTest.scala
@@ -59,10 +59,9 @@ class SimpleBerryClientTest extends TestkitExample with SpecificationLike with M
 
       sender.expectMsg(JsArray(Seq(JsArray(Seq(Json.obj("a" -> 4), Json.obj("b" -> 8))))))
 
-      //Disabled this suggest views in RESTSolver.
-      //dataManager.expectMsg(DataStoreManager.AskInfoAndViews(query.dataset))
-      //dataManager.reply(Seq(sourceInfo))
-      //dataManager.expectMsg(create)
+      dataManager.expectMsg(DataStoreManager.AskInfoAndViews(query.dataset))
+      dataManager.reply(Seq(sourceInfo))
+      dataManager.expectMsg(create)
       ok
     }
     "send the NoSuchData msg if the request is on a unknown dataset" in {


### PR DESCRIPTION
Since current Twittermap does not send the Sample Tweets query to Cloudberry anymore, the competition on resources of RestfulSolver suggesting view with running ProgressiveSolver does not happen now #501, we enable the suggesting view function again in RestfulSolver.

**Note: `suggestView` operation in RestfulSolver or ProgressiveSolver is only a triggering signal sent to QueryPlanner, the real decision of whether we need to create a view and what view to create should be made by QueryPannner**