### PR TITLE
[Backend] Make view maintenance enable/disable configurable.

### DIFF
--- a/cloudberry/neo/app/controllers/Cloudberry.scala
+++ b/cloudberry/neo/app/controllers/Cloudberry.scala
@@ -86,14 +86,14 @@ class Cloudberry @Inject()(val wsClient: WSClient,
 
   def ws = WebSocket.accept[JsValue, JsValue] { request =>
     ActorFlow.actorRef { out =>
-      RequestRouter.props(BerryClient.props(new JSONParser(), manager, new QueryPlanner(), config, out), config, request)
+      RequestRouter.props(BerryClient.props(new JSONParser(), manager, new QueryPlanner(config), config, out), config, request)
     }
   }
 
   // A WebSocket for checking whether a query is solvable by view
   def checkQuerySolvableByView = WebSocket.accept[JsValue, JsValue] { request =>
     ActorFlow.actorRef { out =>
-      RequestRouter.props(ViewStatusClient.props(new JSONParser(), manager, new QueryPlanner(), config, out), config, request)
+      RequestRouter.props(ViewStatusClient.props(new JSONParser(), manager, new QueryPlanner(config), config, out), config, request)
     }
   }
 
@@ -108,7 +108,7 @@ class Cloudberry @Inject()(val wsClient: WSClient,
     val source = Source.single(request.body)
 
     val flow = Cloudberry.actorFlow[JsValue, JsValue]({ out =>
-      BerryClient.props(new JSONParser(), manager, new QueryPlanner(), config, out)
+      BerryClient.props(new JSONParser(), manager, new QueryPlanner(config), config, out)
     }, BerryClient.Done)
     val toStringFlow = Flow[JsValue].map(js => js.toString() + System.lineSeparator())
     Ok.chunked((source via flow) via toStringFlow)

--- a/cloudberry/neo/conf/application.conf
+++ b/cloudberry/neo/conf/application.conf
@@ -58,6 +58,16 @@ akka {
       }
     }
   }
+  test {
+    timefactor = 1.0
+    filter-leeway = 10s
+    single-expect-default = 10s
+    default-timeout = 10s
+
+    calling-thread-dispatcher {
+      type = akka.testkit.CallingThreadDispatcherConfigurator
+    }
+  }
 }
 
 play {

--- a/cloudberry/neo/conf/application.conf
+++ b/cloudberry/neo/conf/application.conf
@@ -79,6 +79,8 @@ actor {
   user.timeout = "500 seconds"
 }
 
+view.enable = true
+
 view.update.interval = "30 minutes"
 
 view.meta.flush.interval = "30 minutes"

--- a/cloudberry/neo/conf/production.conf
+++ b/cloudberry/neo/conf/production.conf
@@ -79,6 +79,8 @@ actor {
   user.timeout = "500 seconds"
 }
 
+view.enable = true
+
 view.update.interval = "30 minutes"
 
 view.meta.flush.interval = "30 minutes"
@@ -87,8 +89,10 @@ berry.firstquery.gap = "2 days"
 berry.query.gap = "1 day"
 
 asterixdb.url = "http://localhost:19002/query/service"
+
 #acceptable values: "AQL" or "SQLPP" or "sparksql" or "SQL"
 asterixdb.lang = SQLPP
+
 asterixdb.view.meta.name = "viewMeta"
 
 # WebSocket message size limit

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/common/Config.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/common/Config.scala
@@ -22,7 +22,7 @@ class Config(config: Configuration) {
 
   val UserTimeOut = config.getString("actor.user.timeout").map(parseTimePair).getOrElse(60 seconds)
 
-  val viewMaintenaceEnable = config.getBoolean("view.enable").getOrElse(true)
+  val viewMaintenanceEnable = config.getBoolean("view.enable").getOrElse(true)
 
   val ViewUpdateInterval = config.getString("view.update.interval").map(parseTimePair).getOrElse(60 minutes)
 

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/common/Config.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/common/Config.scala
@@ -22,6 +22,8 @@ class Config(config: Configuration) {
 
   val UserTimeOut = config.getString("actor.user.timeout").map(parseTimePair).getOrElse(60 seconds)
 
+  val viewMaintenaceEnable = config.getBoolean("view.enable").getOrElse(true)
+
   val ViewUpdateInterval = config.getString("view.update.interval").map(parseTimePair).getOrElse(60 minutes)
 
   val ViewMetaFlushInterval = config.getString("view.meta.flush.interval").map(parseTimePair).getOrElse(60 minutes)

--- a/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlanner.scala
+++ b/cloudberry/zion/src/main/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlanner.scala
@@ -13,7 +13,7 @@ class QueryPlanner (val config: Config) {
 
   def makePlan(query: Query, source: DataSetInfo, views: Seq[DataSetInfo]): (Seq[Query], IMerger) = {
 
-    config.viewMaintenaceEnable match {
+    config.viewMaintenanceEnable match {
       case true =>
         //TODO currently only get the best one
         val bestView = selectBestView(findMatchedViews(query, source, views))
@@ -34,7 +34,7 @@ class QueryPlanner (val config: Config) {
   }
 
   def suggestNewView(query: Query, source: DataSetInfo, views: Seq[DataSetInfo]): Seq[CreateView] = {
-    config.viewMaintenaceEnable match {
+    config.viewMaintenanceEnable match {
       case true =>
         //TODO currently only suggest the keyword subset views
         if (views.exists(v => v.createQueryOpt.exists(vq => vq.canSolve(query, source.schema)))) {

--- a/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlannerTest.scala
+++ b/cloudberry/zion/src/test/scala/edu/uci/ics/cloudberry/zion/model/impl/QueryPlannerTest.scala
@@ -1,5 +1,6 @@
 package edu.uci.ics.cloudberry.zion.model.impl
 
+import edu.uci.ics.cloudberry.zion.common.Config
 import edu.uci.ics.cloudberry.zion.model.schema._
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
@@ -16,7 +17,7 @@ class QueryPlannerTest extends Specification {
   val queryTag = new Query(TwitterDataSet, Seq.empty,  Seq.empty, filter, Seq(unnestHashTag), Some(groupTag), Some(selectTop10Tag))
   val querySample = new Query(TwitterDataSet, Seq.empty,  Seq.empty, filter, Seq.empty, None, Some(selectRecent))
 
-  val planner = new QueryPlanner
+  val planner = new QueryPlanner(Config.Default)
 
   val zikaFullStats = Stats(sourceInterval.getStart, sourceInterval.getEnd, sourceInterval.getEnd, 50)
   val zikaFullYearViewInfo = DataSetInfo("zika", Some(zikaCreateQuery), twitterSchema, sourceInterval, zikaFullStats)


### PR DESCRIPTION
By setting `view.enable = true/false` to enable or disable view maintenance mechanism in Cloudberry.