### PR TITLE
Fix wss endpoint config

### DIFF
--- a/cloudberry/neo/conf/routes
+++ b/cloudberry/neo/conf/routes
@@ -4,8 +4,8 @@
 
 # cloudberry routes
 GET        /                                    controllers.Cloudberry.index
-GET        /ws/main                             controllers.Cloudberry.ws
-GET        /ws/checkQuerySolvableByView         controllers.Cloudberry.checkQuerySolvableByView
+GET        /ws                                  controllers.Cloudberry.ws
+GET        /checkQuerySolvableByView            controllers.Cloudberry.checkQuerySolvableByView
 POST       /berry                               controllers.Cloudberry.berryQuery
 POST       /webregister                         controllers.Cloudberry.webRegister
 POST       /admin/register                      controllers.Cloudberry.register

--- a/cloudberry/neo/conf/routes
+++ b/cloudberry/neo/conf/routes
@@ -4,8 +4,8 @@
 
 # cloudberry routes
 GET        /                                    controllers.Cloudberry.index
-GET        /ws                                  controllers.Cloudberry.ws
-GET        /checkQuerySolvableByView            controllers.Cloudberry.checkQuerySolvableByView
+GET        /ws/main                             controllers.Cloudberry.ws
+GET        /ws/checkQuerySolvableByView         controllers.Cloudberry.checkQuerySolvableByView
 POST       /berry                               controllers.Cloudberry.berryQuery
 POST       /webregister                         controllers.Cloudberry.webRegister
 POST       /admin/register                      controllers.Cloudberry.register

--- a/examples/coronavirustwittermap/web/app/controllers/TwitterMapApplication.scala
+++ b/examples/coronavirustwittermap/web/app/controllers/TwitterMapApplication.scala
@@ -43,6 +43,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   val cloudberryHost: String = config.getString("cloudberry.host").getOrElse("localhost")
   val cloudberryPort: String = config.getString("cloudberry.port").getOrElse("9000")
   val sentimentEnabled: Boolean = config.getBoolean("sentimentEnabled").getOrElse(false)
+  val appWS: String = config.getString("app.ws").getOrElse("ws://")
   val sentimentUDF: String = config.getString("sentimentUDF").getOrElse("twitter.`snlp#getSentimentScore`(text)")
   val removeSearchBar: Boolean = config.getBoolean("removeSearchBar").getOrElse(false)
   val predefinedKeywords: Seq[String] = config.getStringSeq("predefinedKeywords").getOrElse(Seq())

--- a/examples/coronavirustwittermap/web/app/views/twittermap/main.scala.html
+++ b/examples/coronavirustwittermap/web/app/views/twittermap/main.scala.html
@@ -39,9 +39,7 @@
 
   <script>
     var config= {
-      cloudberryWS: "@TMAobject.cloudberryWS",
-      cloudberryHost: "@TMAobject.cloudberryHost",
-      cloudberryPort: "@TMAobject.cloudberryPort",
+      appWS: "@TMAobject.appWS",
       sentimentEnabled: @TMAobject.sentimentEnabled,
       sentimentUDF: "@TMAobject.sentimentUDF",
       startDate: new Date("@TMAobject.startDate"),

--- a/examples/coronavirustwittermap/web/conf/application.conf
+++ b/examples/coronavirustwittermap/web/conf/application.conf
@@ -86,6 +86,10 @@ cloudberry.ws = "ws://"
 # if using https
 # cloudberry.ws = "wss://"
 
+app.ws = "ws://"
+# if using https
+# app.ws = "wss://"
+
 # Maximum allowable text message size of the web socket
 maxTextMessageSize = 20971520 # 20MB
 

--- a/examples/coronavirustwittermap/web/conf/production.conf
+++ b/examples/coronavirustwittermap/web/conf/production.conf
@@ -85,6 +85,11 @@ cloudberry.ws = "ws://"
 # if using https
 # cloudberry.ws = "wss://"
 
+app.ws = "ws://"
+# if using https
+# app.ws = "wss://"
+
+
 # Maximum allowable text message size of the web socket
 maxTextMessageSize = 20971520 # 20MB
 

--- a/examples/coronavirustwittermap/web/conf/routes
+++ b/examples/coronavirustwittermap/web/conf/routes
@@ -4,11 +4,11 @@
 
 # TwitterMap routes
 GET        /                                    controllers.TwitterMapApplication.index
-GET        /ws                                  controllers.TwitterMapApplication.ws
+GET        /ws/main                             controllers.TwitterMapApplication.ws
 GET        /drugmap                             controllers.TwitterMapApplication.drugmap
-GET        /checkQuerySolvableByView            controllers.TwitterMapApplication.checkQuerySolvableByView
-GET        /liveTweets                          controllers.TwitterMapApplication.liveTweets
-GET        /autoComplete                        controllers.TwitterMapApplication.autoComplete
+GET        /ws/checkQuerySolvableByView         controllers.TwitterMapApplication.checkQuerySolvableByView
+GET        /ws/liveTweets                       controllers.TwitterMapApplication.liveTweets
+GET        /ws/autoComplete                     controllers.TwitterMapApplication.autoComplete
 GET        /city/:neLat/:swLat/:neLng/:swLng    controllers.TwitterMapApplication.getCity(neLat: Double, swLat: Double, neLng: Double, swLng: Double)
 GET        /cityPopulation/:cityIds             controllers.TwitterMapApplication.getCityPop(cityIds: String)
 GET        /stateCases                          controllers.TwitterMapApplication.getStateCases

--- a/examples/coronavirustwittermap/web/public/javascripts/common/cloudberry-client.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/common/cloudberry-client.js
@@ -97,7 +97,7 @@ angular.module("cloudberry.common")
      *   // Handle to the new websocket instance
      *   var ws;
      *   // Use this interface to create a new websocket instance
-     *   var wsConn = cloudberryClient.newWebSocket("ws://"+window.location.host+"/liveTweets");
+     *   var wsConn = cloudberryClient.newWebSocket("ws://"+window.location.host+"/ws/liveTweets");
      *   // Do anything to the websocket in the .done() callback function
      *   // This will make sure the instance you got is connected and referable
      *   wsConn.done(function(pws) {
@@ -149,7 +149,7 @@ angular.module("cloudberry.common")
     };
 
     // Create a native websocket connection used by this client's send interface
-    var wsConnection = this.newWebSocket(cloudberryConfig.ws + window.location.host  + "/ws");
+    var wsConnection = this.newWebSocket(cloudberryConfig.ws + window.location.host  + "/ws/main");
 
     wsConnection.done(function (pws) {
       ws = pws;

--- a/examples/coronavirustwittermap/web/public/javascripts/common/services.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/common/services.js
@@ -57,7 +57,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
     var defaultHeatmapLimit = parseInt(config.heatmapSamplingLimit);
     var defaultPinmapSamplingDayRange = parseInt(config.pinmapSamplingDayRange);
     var defaultPinmapLimit = parseInt(config.pinmapSamplingLimit);
-    var ws = new WebSocket(cloudberryConfig.ws + window.location.host + "/ws");
+    var ws = new WebSocket(cloudberryConfig.ws + window.location.host + "/ws/main");
     // The MapResultCache.getGeoIdsNotInCache() method returns the geoIds
     // not in the cache for the current query.
     var geoIdsNotInCache = [];

--- a/examples/coronavirustwittermap/web/public/javascripts/common/services.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/common/services.js
@@ -1,7 +1,7 @@
 angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.timeseriescache'])
   .factory('cloudberryConfig', function(){
     return {
-      ws: config.cloudberryWS,
+      ws: config.appWS,
       sentimentEnabled: config.sentimentEnabled,
       sentimentUDF: config.sentimentUDF,
       removeSearchBar: config.removeSearchBar,

--- a/examples/coronavirustwittermap/web/public/javascripts/common/services.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/common/services.js
@@ -2,8 +2,6 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
   .factory('cloudberryConfig', function(){
     return {
       ws: config.cloudberryWS,
-      host:config.cloudberryHost,
-      port:config.cloudberryPort,
       sentimentEnabled: config.sentimentEnabled,
       sentimentUDF: config.sentimentUDF,
       removeSearchBar: config.removeSearchBar,
@@ -59,7 +57,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
     var defaultHeatmapLimit = parseInt(config.heatmapSamplingLimit);
     var defaultPinmapSamplingDayRange = parseInt(config.pinmapSamplingDayRange);
     var defaultPinmapLimit = parseInt(config.pinmapSamplingLimit);
-    var ws = new WebSocket(cloudberryConfig.ws + cloudberryConfig.host + ":" + cloudberryConfig.port + "/ws");
+    var ws = new WebSocket(cloudberryConfig.ws + window.location.host + "/ws");
     // The MapResultCache.getGeoIdsNotInCache() method returns the geoIds
     // not in the cache for the current query.
     var geoIdsNotInCache = [];

--- a/examples/coronavirustwittermap/web/public/javascripts/searchbar/controllers.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/searchbar/controllers.js
@@ -6,7 +6,7 @@ angular.module('cloudberry.util', ['cloudberry.common'])
     $("#keyword-textbox").autocomplete({source:[],disabled:true,delay:200});
 
     var ACSocket;
-    cloudberryClient.newWebSocket(cloudberryConfig.ws + window.location.host + "/autoComplete").done(function (pws) {
+    cloudberryClient.newWebSocket(cloudberryConfig.ws + window.location.host + "/ws/autoComplete").done(function (pws) {
       ACSocket = pws;
 
       ACSocket.onmessage = function (event) {

--- a/examples/coronavirustwittermap/web/public/javascripts/sidebar/controllers.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/sidebar/controllers.js
@@ -67,7 +67,7 @@ angular.module("cloudberry.sidebar", ["cloudberry.common"])
       queryToCheck["transform"] = {
         wrap: {
           id: cloudberry.parameters.keywords.toString(),
-          category: "ws/checkQuerySolvableByView"
+          category: "checkQuerySolvableByView"
         }
       };
       $scope.nowQueryID = cloudberry.parameters.keywords.toString();

--- a/examples/coronavirustwittermap/web/public/javascripts/sidebar/controllers.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/sidebar/controllers.js
@@ -67,7 +67,7 @@ angular.module("cloudberry.sidebar", ["cloudberry.common"])
       queryToCheck["transform"] = {
         wrap: {
           id: cloudberry.parameters.keywords.toString(),
-          category: "checkQuerySolvableByView"
+          category: "ws/checkQuerySolvableByView"
         }
       };
       $scope.nowQueryID = cloudberry.parameters.keywords.toString();
@@ -80,7 +80,7 @@ angular.module("cloudberry.sidebar", ["cloudberry.common"])
 
     // A WebSocket that send query to Cloudberry, to check whether it is solvable by view
     var wsCheckQuerySolvableByView;
-    cloudberryClient.newWebSocket(cloudberryConfig.ws + window.location.host + '/checkQuerySolvableByView').done(function(pws) {
+    cloudberryClient.newWebSocket(cloudberryConfig.ws + window.location.host + '/ws/checkQuerySolvableByView').done(function(pws) {
       wsCheckQuerySolvableByView = pws;
 
       moduleManager.publishEvent(moduleManager.EVENT.WS_CHECK_QUERY_SOLVABLE_BY_VIEW_READY, {});
@@ -122,7 +122,7 @@ angular.module("cloudberry.sidebar", ["cloudberry.common"])
 
     // WebSocket for Live Tweets
     var LTSocket;
-    cloudberryClient.newWebSocket(cloudberryConfig.ws + window.location.host + "/liveTweets").done(function (pws) {
+    cloudberryClient.newWebSocket(cloudberryConfig.ws + window.location.host + "/ws/liveTweets").done(function (pws) {
         LTSocket = pws;
 
         /* fetchTweetFromAPI sends a query to twittermap server through websocket


### PR DESCRIPTION
- The frontend was contacting cloudberry directly on cloudberry host defined in config (`cloudberry.host` and `cloudberry.port`). Now switched to `window.location`
- All the ws end points are prefixed with `/ws`
   - The original `/ws` end point is now called `/ws/main`  