### PR TITLE
[Frontend] Add configurable pinmap alert messages

### DIFF
--- a/examples/coronavirustwittermap/web/app/controllers/TwitterMapApplication.scala
+++ b/examples/coronavirustwittermap/web/app/controllers/TwitterMapApplication.scala
@@ -70,6 +70,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   val pinmapSamplingDayRange: String = config.getString("pinmap.samplingDayRange").getOrElse("30")
   val pinmapSamplingLimit: String = config.getString("pinmap.samplingLimit").getOrElse("5000")
   val pinmapBinaryTransfer: Boolean = config.getBoolean("pinmap.binaryTransfer").getOrElse(false)
+  val pinmapAlertMessages: Seq[String] = config.getStringSeq("pinmap.alertMessages").getOrElse(Seq())
   val defaultMapType: String = config.getString("defaultMapType").getOrElse("countmap")
   val liveTweetDefaultKeyword: String = config.getString("liveTweetDefaultKeyword").getOrElse(null)
   val liveTweetQueryInterval : Int = config.getInt("liveTweetQueryInterval").getOrElse(60)

--- a/examples/coronavirustwittermap/web/app/views/twittermap/main.scala.html
+++ b/examples/coronavirustwittermap/web/app/views/twittermap/main.scala.html
@@ -69,6 +69,7 @@
       pinmapSamplingDayRange: @TMAobject.pinmapSamplingDayRange,
       pinmapSamplingLimit: @TMAobject.pinmapSamplingLimit,
       pinMapBinaryTransfer: @TMAobject.pinmapBinaryTransfer,
+      pinmapAlertMessages: @Html(Json.stringify(Json.toJson(TMAobject.pinmapAlertMessages))),
       liveTweetDefaultKeyword: "@TMAobject.liveTweetDefaultKeyword",
       liveTweetQueryInterval: @TMAobject.liveTweetQueryInterval,
       liveTweetQueryOffset: @TMAobject.liveTweetQueryOffset,

--- a/examples/coronavirustwittermap/web/conf/application.conf
+++ b/examples/coronavirustwittermap/web/conf/application.conf
@@ -149,6 +149,8 @@ pinmap.samplingDayRange = 365
 pinmap.samplingLimit = 50000
 # Wheter use binary format to transfer pinmap result data. (Default: false)
 pinmap.binaryTransfer = true
+# Alert messages when initializing pinmap
+pinmap.alertMessages = ["A point on the map is a tweet."]
 
 # Available map types: countmap, pinmap, heatmap.
 # If defaultMapType is not provided, countmap will be used. (Default: "countmap")

--- a/examples/coronavirustwittermap/web/public/javascripts/common/services.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/common/services.js
@@ -14,6 +14,7 @@ angular.module('cloudberry.common', ['cloudberry.mapresultcache', 'cloudberry.ti
       querySliceMills: parseInt(config.querySliceMills),
       pinMapOneTweetLookUpResult: null,
       pinMapBinaryTransfer: config.pinMapBinaryTransfer,
+      pinmapAlertMessages: config.pinmapAlertMessages,
       timeSeriesChartType: config.timeSeriesChartType,
       timeSeriesGroupBy: config.timeSeriesGroupBy,
       popupWindowChartType: config.popupWindowChartType,

--- a/examples/coronavirustwittermap/web/public/javascripts/map/controllers.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/map/controllers.js
@@ -10,7 +10,7 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
     // L.Browser.gecko3d: true for gecko-based browsers supporting CSS transforms.
     if (L.Browser.gecko || L.Browser.gecko3d) {
       var alertDiv = document.getElementsByTagName("alert-bar")[0];
-      var div = L.DomUtil.create('div', 'alert alert-warning alert-dismissible')
+      var div = L.DomUtil.create('div', 'alert alert-warning alert-dismissible');
       div.innerHTML = [
         '<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>',
         '<p>TwitterMap currently doesn\'t support time series chart on Firefox.</p>',
@@ -451,6 +451,28 @@ angular.module('cloudberry.map', ['leaflet-directive', 'cloudberry.common','clou
       randomizationSeed = seed;
       var ret = randomNorm((minV + maxV) / 2, (maxV - minV) / 16);
       return ret;
+    };
+
+    // show alert message for a given time duration
+    $scope.alertMessage = function(messages, seconds) {
+      var alertDiv = document.getElementsByTagName("alert-bar")[0];
+      var div = L.DomUtil.create('div', 'alert alert-info alert-dismissible');
+      var messagesArray = [];
+      for (var i = 0; i < messages.length; i ++) {
+        messagesArray.push('<p>' + messages[i] + '</p>');
+      }
+      div.innerHTML = '<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>' + messagesArray.join('');
+      div.style.position = 'absolute';
+      div.style.top = '0%';
+      div.style.width = '100%';
+      div.style.zIndex = '9999';
+      div.style.fontSize = '23px';
+      alertDiv.appendChild(div);
+      if (seconds > 0) {
+        $("alert-bar").fadeTo(seconds * 1000, 500).slideUp(500, function () {
+          $("alert-bar").slideUp(500);
+        });
+      }
     };
 
     $scope.onEachFeature = null;

--- a/examples/coronavirustwittermap/web/public/javascripts/map/pinmap.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/map/pinmap.js
@@ -449,6 +449,9 @@ angular.module("cloudberry.map")
             setPinMapStyle();
             $scope.resetPolygonLayers();
             setInfoControlPinMap();
+            if (cloudberryConfig.pinmapAlertMessages && cloudberryConfig.pinmapAlertMessages.length > 0) {
+                $scope.alertMessage(cloudberryConfig.pinmapAlertMessages, 5);
+            }
         }
 
         // map type change handler


### PR DESCRIPTION
Set up alert messages using `pinmap.alertMessages=["message1", "message2"]` which will be alerted when `pinmap` is initializing as default map type.