### PR TITLE
fix livetweet not showing on chrome

### DIFF
--- a/examples/coronavirustwittermap/web/public/javascripts/sidebar/controllers.js
+++ b/examples/coronavirustwittermap/web/public/javascripts/sidebar/controllers.js
@@ -111,7 +111,7 @@ angular.module("cloudberry.sidebar", ["cloudberry.common"])
       $http.jsonp(url).success(function (data) {
         $(data.html).hide().prependTo("#tweet");
         window.setTimeout(function(){
-          $("#tweet").children().filter("twitter-widget").first().removeClass("twitter-tweet").hide(0,function(){
+          $("#tweet").children().first().removeClass("twitter-tweet").hide(0,function(){
             if ($("#loadingAnime").length !== 0) {
               $("#loadingAnime").remove();
             }

--- a/examples/twittermap/web/public/javascripts/sidebar/controllers.js
+++ b/examples/twittermap/web/public/javascripts/sidebar/controllers.js
@@ -111,7 +111,7 @@ angular.module("cloudberry.sidebar", ["cloudberry.common"])
       $http.jsonp(url).success(function (data) {
         $(data.html).hide().prependTo("#tweet");
         window.setTimeout(function(){
-          $("#tweet").children().filter("twitter-widget").first().removeClass("twitter-tweet").hide(0,function(){
+          $("#tweet").children().first().removeClass("twitter-tweet").hide(0,function(){
             if ($("#loadingAnime").length !== 0) {
               $("#loadingAnime").remove();
             }


### PR DESCRIPTION
Live tweet was not showing on Chrome
<img src="https://user-images.githubusercontent.com/9158114/85899097-3c58f980-b806-11ea-9acc-285c802db596.png" height="200">
Because it doesn't recognize the element `twitter-widget` in the check possibly due to a change in the security on chrome for iframes
the update is to remove this filter
<img src="https://user-images.githubusercontent.com/9158114/85899484-d1f48900-b806-11ea-82d7-a2f0705bebb8.png" height="200">

