### PR TITLE
[Bug Fix] HashTag button always unclickable.

### DIFF
--- a/examples/twittermap/web/app/controllers/TwitterMapApplication.scala
+++ b/examples/twittermap/web/app/controllers/TwitterMapApplication.scala
@@ -137,7 +137,7 @@ class TwitterMapApplication @Inject()(val wsClient: WSClient,
   }
 
   // A WebSocket that send query to Cloudberry, to check whether it is solvable by view
-  def checkQuerySolvableByView = WebSocket.accept[JsValue, JsValue] { request =>
+  def checkQuerySolvableByView = WebSocket.accept[JsValue, WSMessage] { request =>
     ActorFlow.actorRef { out =>
       TwitterMapPigeon.props(webSocketFactory, cloudberryWS + cloudberryHost + ":" + cloudberryPort + "/checkQuerySolvableByView", out, config, maxTextMessageSize)
     }


### PR DESCRIPTION
## Symptom
The HashTag button on the sidebar is always unclickable.

## Reason
When a new keyword query is issued, the sidebar sends a request to Cloudberry asking if the query is `solvable` by a view every 1 second. The HashTag button only turns clickable once it receives a response saying YES.  However, one bug in the WebSocket interface for the `solvable` request always throws an exception when a response is received, which results in the WebSocket channel being closed.  The exception is due to a type-mismatch between the WebSocket interface declaration and the real response message rendered to the channel.

## Solution
Just change the declared response message type from `JsValue` to `WSMessage`, because the response message is rendered using `Left(json)` instead of `json`.  Here `WSMessage` is a `Either(JsValue, Array[Byte])` type, and the `Left(json)` means it is the `Left` of the `Either` type but not a `JsValue` type.